### PR TITLE
fix compilation and a few clippy lints

### DIFF
--- a/klickhouse/src/client.rs
+++ b/klickhouse/src/client.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 
+use anyhow::anyhow;
+use anyhow::Result;
 use futures::{stream, Stream, StreamExt};
 use indexmap::IndexMap;
 use protocol::CompressionMethod;
@@ -24,7 +26,6 @@ use crate::{
     io::{ClickhouseRead, ClickhouseWrite},
     protocol::{self, ServerPacket},
 };
-use anyhow::*;
 use log::*;
 
 struct InnerClient<R: ClickhouseRead, W: ClickhouseWrite> {

--- a/klickhouse/src/internal_client_out.rs
+++ b/klickhouse/src/internal_client_out.rs
@@ -26,7 +26,7 @@ pub struct ClientHello<'a> {
 
 #[repr(u8)]
 #[derive(PartialEq, Clone, Copy)]
-#[allow(unused)]
+#[allow(unused, clippy::enum_variant_names)]
 pub enum QueryKind {
     NoQuery,
     InitialQuery,

--- a/klickhouse/src/io.rs
+++ b/klickhouse/src/io.rs
@@ -1,5 +1,5 @@
-use anyhow::*;
-use std::io::Result;
+use anyhow::anyhow;
+use anyhow::Result;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -29,6 +29,7 @@ impl<T: AsyncRead + Unpin + Send + Sync> ClickhouseRead for T {
         Ok(out)
     }
 
+    #[allow(clippy::uninit_vec)]
     async fn read_string(&mut self) -> anyhow::Result<String> {
         let len = self.read_var_uint().await?;
         if len as usize > MAX_STRING_SIZE {
@@ -42,6 +43,7 @@ impl<T: AsyncRead + Unpin + Send + Sync> ClickhouseRead for T {
         Ok(String::from_utf8(buf)?)
     }
 
+    #[allow(clippy::uninit_vec)]
     async fn read_binary(&mut self) -> anyhow::Result<Vec<u8>> {
         let len = self.read_var_uint().await?;
         if len as usize > MAX_STRING_SIZE {

--- a/klickhouse/src/types/deserialize/string.rs
+++ b/klickhouse/src/types/deserialize/string.rs
@@ -7,6 +7,7 @@ use super::{Deserializer, DeserializerState, Type};
 
 pub struct StringDeserializer;
 
+#[allow(clippy::uninit_vec)]
 #[async_trait::async_trait]
 impl Deserializer for StringDeserializer {
     async fn read<R: ClickhouseRead>(

--- a/klickhouse/src/values/date.rs
+++ b/klickhouse/src/values/date.rs
@@ -30,9 +30,9 @@ impl FromSql for Date {
     }
 }
 
-impl Into<chrono::Date<Utc>> for Date {
-    fn into(self) -> chrono::Date<Utc> {
-        chrono::MIN_DATE + Duration::days(self.0 as i64)
+impl From<Date> for chrono::Date<Utc> {
+    fn from(date: Date) -> Self {
+        chrono::MIN_DATE + Duration::days(date.0 as i64)
     }
 }
 
@@ -70,9 +70,9 @@ impl Default for DateTime {
     }
 }
 
-impl Into<chrono::DateTime<Tz>> for DateTime {
-    fn into(self) -> chrono::DateTime<Tz> {
-        chrono::MIN_DATETIME.with_timezone(&self.0) + Duration::seconds(self.1 as i64)
+impl From<DateTime> for chrono::DateTime<Tz> {
+    fn from(date: DateTime) -> Self {
+        chrono::MIN_DATETIME.with_timezone(&date.0) + Duration::seconds(date.1 as i64)
     }
 }
 
@@ -126,9 +126,9 @@ impl<const PRECISION: usize> Default for DateTime64<PRECISION> {
     }
 }
 
-impl<const PRECISION: usize> Into<chrono::DateTime<Tz>> for DateTime64<PRECISION> {
-    fn into(self) -> chrono::DateTime<Tz> {
-        chrono::MIN_DATETIME.with_timezone(&self.0) + Duration::seconds(self.1 as i64)
+impl<const PRECISION: usize> From<DateTime64<PRECISION>> for chrono::DateTime<Tz> {
+    fn from(date: DateTime64<PRECISION>) -> Self {
+        chrono::MIN_DATETIME.with_timezone(&date.0) + Duration::seconds(date.1 as i64)
     }
 }
 

--- a/klickhouse/src/values/fixed_point.rs
+++ b/klickhouse/src/values/fixed_point.rs
@@ -42,9 +42,9 @@ impl<const PRECISION: u64> FromSql for FixedPoint32<PRECISION> {
     }
 }
 
-impl<const PRECISION: u64> Into<f64> for FixedPoint32<PRECISION> {
-    fn into(self) -> f64 {
-        self.integer() as f64 + (self.fraction() as f64 / self.modulus() as f64)
+impl<const PRECISION: u64> From<FixedPoint32<PRECISION>> for f64 {
+    fn from(fp: FixedPoint32<PRECISION>) -> Self {
+        fp.integer() as f64 + (fp.fraction() as f64 / fp.modulus() as f64)
     }
 }
 
@@ -84,9 +84,9 @@ impl<const PRECISION: u64> FixedPoint64<PRECISION> {
     }
 }
 
-impl<const PRECISION: u64> Into<f64> for FixedPoint64<PRECISION> {
-    fn into(self) -> f64 {
-        self.integer() as f64 + (self.fraction() as f64 / self.modulus() as f64)
+impl<const PRECISION: u64> From<FixedPoint64<PRECISION>> for f64 {
+    fn from(fp: FixedPoint64<PRECISION>) -> Self {
+        fp.integer() as f64 + (fp.fraction() as f64 / fp.modulus() as f64)
     }
 }
 
@@ -126,9 +126,9 @@ impl<const PRECISION: u64> FixedPoint128<PRECISION> {
     }
 }
 
-impl<const PRECISION: u64> Into<f64> for FixedPoint128<PRECISION> {
-    fn into(self) -> f64 {
-        self.integer() as f64 + (self.fraction() as f64 / self.modulus() as f64)
+impl<const PRECISION: u64> From<FixedPoint128<PRECISION>> for f64 {
+    fn from(fp: FixedPoint128<PRECISION>) -> Self {
+        fp.integer() as f64 + (fp.fraction() as f64 / fp.modulus() as f64)
     }
 }
 

--- a/klickhouse/src/values/int256.rs
+++ b/klickhouse/src/values/int256.rs
@@ -10,9 +10,9 @@ use anyhow::*;
 #[allow(non_camel_case_types)]
 pub struct i256(pub [u8; 32]);
 
-impl Into<u256> for i256 {
-    fn into(self) -> u256 {
-        u256(self.0)
+impl From<i256> for u256 {
+    fn from(i: i256) -> Self {
+        u256(i.0)
     }
 }
 
@@ -34,12 +34,12 @@ impl FromSql for i256 {
     }
 }
 
-impl Into<(u128, u128)> for i256 {
-    fn into(self) -> (u128, u128) {
+impl From<i256> for (u128, u128) {
+    fn from(i: i256) -> Self {
         let mut buf = [0u8; 16];
-        buf.copy_from_slice(&self.0[..16]);
+        buf.copy_from_slice(&i.0[..16]);
         let n1 = u128::from_be_bytes(buf);
-        buf.copy_from_slice(&self.0[16..]);
+        buf.copy_from_slice(&i.0[16..]);
         let n2 = u128::from_be_bytes(buf);
         (n1, n2)
     }
@@ -77,18 +77,18 @@ impl FromSql for u256 {
     }
 }
 
-impl Into<i256> for u256 {
-    fn into(self) -> i256 {
-        i256(self.0)
+impl From<u256> for i256 {
+    fn from(u: u256) -> Self {
+        i256(u.0)
     }
 }
 
-impl Into<(u128, u128)> for u256 {
-    fn into(self) -> (u128, u128) {
+impl From<u256> for (u128, u128) {
+    fn from(u: u256) -> Self {
         let mut buf = [0u8; 16];
-        buf.copy_from_slice(&self.0[..16]);
+        buf.copy_from_slice(&u.0[..16]);
         let n1 = u128::from_be_bytes(buf);
-        buf.copy_from_slice(&self.0[16..]);
+        buf.copy_from_slice(&u.0[16..]);
         let n2 = u128::from_be_bytes(buf);
         (n1, n2)
     }

--- a/klickhouse/src/values/ip.rs
+++ b/klickhouse/src/values/ip.rs
@@ -23,9 +23,9 @@ impl Deref for Ipv4 {
     }
 }
 
-impl Into<Ipv4Addr> for Ipv4 {
-    fn into(self) -> Ipv4Addr {
-        self.0
+impl From<Ipv4> for Ipv4Addr {
+    fn from(i: Ipv4) -> Self {
+        i.0
     }
 }
 
@@ -59,9 +59,9 @@ impl Deref for Ipv6 {
     }
 }
 
-impl Into<Ipv6Addr> for Ipv6 {
-    fn into(self) -> Ipv6Addr {
-        self.0
+impl From<Ipv6> for Ipv6Addr {
+    fn from(i: Ipv6) -> Self {
+        i.0
     }
 }
 

--- a/klickhouse_derive/src/attr.rs
+++ b/klickhouse_derive/src/attr.rs
@@ -337,6 +337,7 @@ pub struct Field {
     bound: Option<Vec<syn::WherePredicate>>,
 }
 
+#[allow(clippy::enum_variant_names)]
 /// Represents the default to use for a field when deserializing.
 pub enum Default {
     /// Field must always be specified because it does not have a default.

--- a/klickhouse_derive/src/row.rs
+++ b/klickhouse_derive/src/row.rs
@@ -157,7 +157,7 @@ fn serialize_struct_visitor(fields: &[Field], params: &Parameters) -> Vec<TokenS
         .map(|field| {
             let member = &field.member;
 
-            let field_expr = get_member(params, &member);
+            let field_expr = get_member(params, member);
 
             let key_expr = field.attrs.name().name();
 


### PR DESCRIPTION
The lib failed to compile on my version of rust (stable 1.58), so I went ahead and fixed the errors