### PR TITLE
fix compilation on some ARM architectures

### DIFF
--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4"
 chrono-tz = "0.8"
 futures = "0.3"
 tokio-stream = "0.1"
+libc = "0.2"
 lz4 = { version = "1.24", optional = true }
 klickhouse_derive = { version = "=0.8.2", optional = true, path = "../klickhouse_derive" }
 cityhash-rs = "1.0"

--- a/klickhouse/src/compression.rs
+++ b/klickhouse/src/compression.rs
@@ -13,8 +13,8 @@ pub async fn compress_block(block: Block, revision: u64) -> Result<(Vec<u8>, usi
     let mut compressed = Vec::<u8>::with_capacity(raw.len() + (raw.len() / 255) + 16 + 1);
     let out_len = unsafe {
         lz4::liblz4::LZ4_compress_default(
-            raw.as_ptr() as *const i8,
-            compressed.as_mut_ptr() as *mut i8,
+            raw.as_ptr() as *const libc::c_char,
+            compressed.as_mut_ptr() as *mut libc::c_char,
             raw.len() as i32,
             compressed.capacity() as i32,
         )
@@ -37,8 +37,8 @@ pub async fn decompress_block(data: &[u8], decompressed_size: u32, revision: u64
 
     let out_len = unsafe {
         lz4::liblz4::LZ4_decompress_safe(
-            data.as_ptr() as *const i8,
-            output.as_mut_ptr() as *mut i8,
+            data.as_ptr() as *const libc::c_char,
+            output.as_mut_ptr() as *mut libc::c_char,
             data.len() as i32,
             output.capacity() as i32,
         )


### PR DESCRIPTION
For different OS/compilers, `char *` in a native interface can turn into either `*const i8` or `*const u8`. (char can be signed or unsigned). In klickhouse 0.8.2-0.8.4 (and probably others), I get a compiler error on aarch64 for the type casts in these two calls into lz4. I changed the cast to `*const libc::c_char` and it seems to compile on both x86_64 and aarch64 now. All tests pass on both platforms.
