### PR TITLE
Initial support for geo types (+ minor README improvements)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +465,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567495020b114f1ce9bed679b29975aa0bfae06ac22beacd5cfde5dabe7b05d6"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +620,7 @@ dependencies = [
  "compiler-tools-derive",
  "env_logger",
  "futures",
+ "geo-types",
  "indexmap 2.0.0",
  "klickhouse_derive",
  "libc",
@@ -639,6 +660,12 @@ name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -715,6 +742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "libc",
  "log",
  "lz4",
+ "paste",
  "refinery-core",
  "rust_decimal",
  "rustc_version",
@@ -772,6 +773,12 @@ checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ $ cargo nextest run
 
 (running the tests simultaneously with `cargo test` is currently not suported, due to loggers initializations.)
 
+## Feature flags
+
+- `derive`: Enable [klickhouse_derive], providing a derive macro for the [Row] trait. Default.
+- `compression`: `lz4` compression for client/server communication. Default.
+- `serde`: Derivation of [serde::Serialize] and [serde::Deserialize] on various objects, and JSON support. Default.
+- `tls`: TLS support via [tokio-rustls](https://crates.io/crates/tokio-rustls).
+- `refinery`: Migrations via [refinery](https://crates.io/crates/refinery).
 ## Credit
 
 `klickhouse_derive` was made by copy/paste/simplify of `serde_derive` to get maximal functionality and performance at lowest time-cost. In a prototype, `serde` was directly used, but this was abandoned due to lock-in of `serde`'s data model.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ cargo nextest run
 - `serde`: Derivation of [serde::Serialize] and [serde::Deserialize] on various objects, and JSON support. Default.
 - `tls`: TLS support via [tokio-rustls](https://crates.io/crates/tokio-rustls).
 - `refinery`: Migrations via [refinery](https://crates.io/crates/refinery).
+- `geo-types`: Conversion of geo types to/from the [geo-types](https://crates.io/crates/geo-types) crate.
+
 ## Credit
 
 `klickhouse_derive` was made by copy/paste/simplify of `serde_derive` to get maximal functionality and performance at lowest time-cost. In a prototype, `serde` was directly used, but this was abandoned due to lock-in of `serde`'s data model.

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -42,6 +42,7 @@ rust_decimal = { version = "1.30", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 tokio-rustls = { version = "0.24.1", optional = true }
+paste = "1.0.14"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -10,6 +10,9 @@ keywords = [ "clickhouse", "database", "tokio", "sql" ]
 readme = "../README.md"
 autotests = false
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[test]]
 name = "test"
 path = "tests/main.rs"

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -43,6 +43,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 tokio-rustls = { version = "0.24.1", optional = true }
 paste = "1.0.14"
+geo-types = {version = "0.7.12", optional = true}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -52,6 +53,7 @@ env_logger = "0.10"
 default = ["derive", "compression", "serde"]
 derive = ["klickhouse_derive"]
 compression = ["lz4"]
+geo-types = ["dep:geo-types"]
 refinery = ["refinery-core", "time"]
 serde = ["dep:serde", "serde_json", "uuid/serde", "chrono/serde"]
 tls = ["tokio-rustls"]

--- a/klickhouse/src/lib.rs
+++ b/klickhouse/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../../README.md")]
+
 /// Clickhouse major version
 pub const VERSION_MAJOR: u64 = 22;
 /// Clickhouse minor version

--- a/klickhouse/src/types/deserialize/array.rs
+++ b/klickhouse/src/types/deserialize/array.rs
@@ -4,22 +4,42 @@ use crate::{io::ClickhouseRead, values::Value, Result};
 
 use super::{Deserializer, DeserializerState, Type};
 
+/// Trait to allow reading `Item`s and packing them into a `Value::*`.
+pub trait ArrayDeserializerGeneric {
+    type Item;
+    /// The type of the items, e.g. [Value]
+    fn inner_type(type_: &Type) -> &Type;
+    /// Mapping from items to the return Value, e.g. simply `Vec<Value> -> Value::Array(items)`.
+    fn inner_value(items: Vec<Self::Item>) -> Value;
+    /// Conversion between the [Value] read and the items, e.g. simply the identity.
+    fn item_mapping(value: Value) -> Self::Item;
+}
+
+/// Simple case for reading into a [Value::Array].
 pub struct ArrayDeserializer;
+impl ArrayDeserializerGeneric for ArrayDeserializer {
+    type Item = Value;
+    fn inner_type(type_: &Type) -> &Type {
+        type_.unwrap_array()
+    }
+    fn inner_value(items: Vec<Self::Item>) -> Value {
+        Value::Array(items)
+    }
+    fn item_mapping(value: Value) -> Value {
+        value
+    }
+}
 
 #[async_trait::async_trait]
-impl Deserializer for ArrayDeserializer {
+impl<T: ArrayDeserializerGeneric + 'static> Deserializer for T {
     async fn read_prefix<R: ClickhouseRead>(
         type_: &Type,
         reader: &mut R,
         state: &mut DeserializerState,
     ) -> Result<()> {
-        match type_ {
-            Type::Array(inner) => {
-                inner.deserialize_prefix(reader, state).await?;
-            }
-            _ => unimplemented!(),
-        }
-        Ok(())
+        Self::inner_type(type_)
+            .deserialize_prefix(reader, state)
+            .await
     }
 
     async fn read<R: ClickhouseRead>(
@@ -28,7 +48,6 @@ impl Deserializer for ArrayDeserializer {
         rows: usize,
         state: &mut DeserializerState,
     ) -> Result<Vec<Value>> {
-        let type_ = type_.unwrap_array();
         if rows == 0 {
             return Ok(vec![]);
         }
@@ -36,16 +55,17 @@ impl Deserializer for ArrayDeserializer {
         for _ in 0..rows {
             offsets.push(reader.read_u64_le().await?);
         }
-        let mut items = type_
+        let mut items = Self::inner_type(type_)
             .deserialize_column(reader, offsets[offsets.len() - 1] as usize, state)
             .await?
-            .into_iter();
+            .into_iter()
+            .map(Self::item_mapping);
         let mut out = Vec::with_capacity(rows);
         let mut read_offset = 0u64;
         for offset in offsets {
             let len = offset - read_offset;
             read_offset = offset;
-            out.push(Value::Array((&mut items).take(len as usize).collect()));
+            out.push(Self::inner_value((&mut items).take(len as usize).collect()));
         }
 
         Ok(out)

--- a/klickhouse/src/types/deserialize/geo.rs
+++ b/klickhouse/src/types/deserialize/geo.rs
@@ -1,0 +1,75 @@
+use crate::{io::ClickhouseRead, values::Value, Result};
+
+use super::{Deserializer, DeserializerState, Type};
+
+use crate::values;
+
+pub struct PointDeserializer;
+
+#[async_trait::async_trait]
+impl Deserializer for PointDeserializer {
+    async fn read_prefix<R: ClickhouseRead>(
+        _type_: &Type,
+        reader: &mut R,
+        state: &mut DeserializerState,
+    ) -> Result<()> {
+        for _ in 0..2 {
+            Type::Float64.deserialize_prefix(reader, state).await?;
+        }
+        Ok(())
+    }
+
+    async fn read<R: ClickhouseRead>(
+        _type_: &Type,
+        reader: &mut R,
+        rows: usize,
+        state: &mut DeserializerState,
+    ) -> Result<Vec<Value>> {
+        let mut points = vec![Value::Point(Default::default()); rows];
+        for col in 0..2 {
+            for (row, value) in Type::Float64
+                .deserialize_column(reader, rows, state)
+                .await?
+                .into_iter()
+                .enumerate()
+            {
+                let Value::Float64(value) = value else {
+                    unreachable!()
+                };
+                match &mut points[row] {
+                    Value::Point(point) => point.0[col] = value,
+                    _ => {
+                        unreachable!()
+                    }
+                }
+            }
+        }
+        Ok(points)
+    }
+}
+macro_rules! array_deser {
+    ($name:ident, $item:ty) => {
+        paste::paste! {
+            pub struct [<$name Deserializer>];
+            impl super::array::ArrayDeserializerGeneric for [<$name Deserializer>] {
+                type Item = crate::values::$item;
+                fn inner_type(_type_: &Type) -> &Type {
+                    &Type::$item
+                }
+                fn inner_value(items: Vec<Self::Item>) -> Value {
+                    Value::$name(values::$name(items))
+                }
+                fn item_mapping(value: Value) -> Self::Item {
+                    let Value::$item(point) = value else {
+                        unreachable!()
+                    };
+                    point
+                }
+            }
+        }
+    };
+}
+
+array_deser!(Ring, Point);
+array_deser!(Polygon, Ring);
+array_deser!(MultiPolygon, Polygon);

--- a/klickhouse/src/types/deserialize/mod.rs
+++ b/klickhouse/src/types/deserialize/mod.rs
@@ -1,4 +1,5 @@
 pub mod array;
+pub mod geo;
 pub mod low_cardinality;
 pub mod map;
 pub mod nullable;

--- a/klickhouse/src/types/serialize/array.rs
+++ b/klickhouse/src/types/serialize/array.rs
@@ -4,22 +4,34 @@ use crate::{io::ClickhouseWrite, values::Value, Result};
 
 use super::{Serializer, SerializerState, Type};
 
+// Trait to allow serializing [Values] wrapping an array of items.
+pub trait ArraySerializerGeneric {
+    fn inner_type(type_: &Type) -> &Type;
+    fn value_len(value: &Value) -> usize;
+    fn values(value: Value) -> Vec<Value>;
+}
+
 pub struct ArraySerializer;
+impl ArraySerializerGeneric for ArraySerializer {
+    fn value_len(value: &Value) -> usize {
+        value.unwrap_array_ref().len()
+    }
+    fn inner_type(type_: &Type) -> &Type {
+        type_.unwrap_array()
+    }
+    fn values(value: Value) -> Vec<Value> {
+        value.unwrap_array()
+    }
+}
 
 #[async_trait::async_trait]
-impl Serializer for ArraySerializer {
+impl<T: ArraySerializerGeneric + 'static> Serializer for T {
     async fn write_prefix<W: ClickhouseWrite>(
         type_: &Type,
         writer: &mut W,
         state: &mut SerializerState,
     ) -> Result<()> {
-        match type_ {
-            Type::Array(inner) => {
-                inner.serialize_prefix(writer, state).await?;
-            }
-            _ => unimplemented!(),
-        }
-        Ok(())
+        T::inner_type(type_).serialize_prefix(writer, state).await
     }
 
     async fn write<W: ClickhouseWrite>(
@@ -28,16 +40,15 @@ impl Serializer for ArraySerializer {
         writer: &mut W,
         state: &mut SerializerState,
     ) -> Result<()> {
-        let type_ = type_.unwrap_array();
+        let type_ = T::inner_type(type_);
         let mut offset = 0usize;
         for value in &values {
-            let inner = value.unwrap_array_ref();
-            offset += inner.len();
+            offset += Self::value_len(value);
             writer.write_u64_le(offset as u64).await?;
         }
-        let mut all_values = Vec::with_capacity(offset);
+        let mut all_values: Vec<Value> = Vec::with_capacity(offset);
         for value in values {
-            all_values.extend(value.unwrap_array());
+            all_values.extend(Self::values(value));
         }
         type_.serialize_column(all_values, writer, state).await?;
         Ok(())

--- a/klickhouse/src/types/serialize/geo.rs
+++ b/klickhouse/src/types/serialize/geo.rs
@@ -1,0 +1,74 @@
+use crate::{io::ClickhouseWrite, values::Value, Result};
+
+use super::{Serializer, SerializerState, Type};
+
+pub struct PointSerializer;
+
+#[async_trait::async_trait]
+impl Serializer for PointSerializer {
+    async fn write_prefix<W: ClickhouseWrite>(
+        _type_: &Type,
+        writer: &mut W,
+        state: &mut SerializerState,
+    ) -> Result<()> {
+        for _ in 0..2 {
+            Type::Float64.serialize_prefix(writer, state).await?;
+        }
+        Ok(())
+    }
+
+    async fn write<W: ClickhouseWrite>(
+        _type_: &Type,
+        values: Vec<Value>,
+        writer: &mut W,
+        state: &mut SerializerState,
+    ) -> Result<()> {
+        let mut columns = vec![Vec::with_capacity(values.len()); 2];
+        for value in values {
+            let Value::Point(point) = value else {
+                unreachable!()
+            };
+            for (i, col) in columns.iter_mut().enumerate() {
+                col.push(Value::Float64(point.0[i]));
+            }
+        }
+        for column in columns {
+            Type::Float64
+                .serialize_column(column, writer, state)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+macro_rules! array_ser {
+    ($name:ident, $item:ty) => {
+        paste::paste! {
+            pub struct [<$name Serializer>];
+            impl super::array::ArraySerializerGeneric for [<$name Serializer>] {
+                fn inner_type(_type_: &Type) -> &Type {
+                    &Type::$item
+                }
+                fn value_len(value: &Value) -> usize {
+                    match value {
+                        Value::$name(array) => array.0.len(),
+                        _ => unreachable!()
+                    }
+                }
+                fn values(value: Value) -> Vec<Value> {
+                    match value {
+                        // The into_iter/collect is annoying, but unavoidable if we want
+                        // to give strong types to the user inside the containers rather than
+                        // [Value]s.
+                        Value::$name(array) => array.0.into_iter().map(Value::$item).collect(),
+                        _ => unreachable!()
+                    }
+                }
+            }
+        }
+    };
+}
+
+array_ser!(Ring, Point);
+array_ser!(Polygon, Ring);
+array_ser!(MultiPolygon, Polygon);

--- a/klickhouse/src/types/serialize/mod.rs
+++ b/klickhouse/src/types/serialize/mod.rs
@@ -1,4 +1,5 @@
 pub mod array;
+pub mod geo;
 pub mod low_cardinality;
 pub mod map;
 pub mod nullable;

--- a/klickhouse/src/values/geo.rs
+++ b/klickhouse/src/values/geo.rs
@@ -1,0 +1,73 @@
+//! Geo types
+//! <https://clickhouse.com/docs/en/sql-reference/data-types/geo>
+use super::*;
+
+#[derive(Clone, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Geo point, represented by its x and y coordinates.
+///
+/// <https://clickhouse.com/docs/en/sql-reference/data-types/geo#point>
+pub struct Point(pub [f64; 2]);
+impl std::hash::Hash for Point {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for x in self.0 {
+            x.to_bits().hash(state);
+        }
+    }
+}
+impl std::ops::Index<u8> for Point {
+    type Output = f64;
+    fn index(&self, index: u8) -> &Self::Output {
+        &self.0[index as usize]
+    }
+}
+impl AsRef<[f64; 2]> for Point {
+    fn as_ref(&self) -> &[f64; 2] {
+        &self.0
+    }
+}
+#[derive(Clone, Hash, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Polygon without holes.
+///
+/// <https://clickhouse.com/docs/en/sql-reference/data-types/geo#ring>
+pub struct Ring(pub Vec<Point>);
+#[derive(Clone, Hash, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Polygon with holes. The first element is the outer polygon, and the following ones are the holes.
+///
+/// <https://clickhouse.com/docs/en/sql-reference/data-types/geo#polygon>
+pub struct Polygon(pub Vec<Ring>);
+#[derive(Clone, Hash, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Union of polygons.
+///
+/// <https://clickhouse.com/docs/en/sql-reference/data-types/geo#multipolygon>
+pub struct MultiPolygon(pub Vec<Polygon>);
+
+macro_rules! to_from_sql {
+    ($name:ident) => {
+        impl ToSql for $name {
+            fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+                Ok(Value::$name(self))
+            }
+        }
+
+        impl FromSql for $name {
+            fn from_sql(type_: &Type, value: Value) -> Result<Self> {
+                if !matches!(type_, Type::$name) {
+                    return Err(unexpected_type(type_));
+                }
+                match value {
+                    Value::$name(x) => Ok(x),
+                    _ => unimplemented!(),
+                }
+            }
+        }
+    };
+}
+
+to_from_sql!(Point);
+to_from_sql!(Ring);
+to_from_sql!(Polygon);
+to_from_sql!(MultiPolygon);

--- a/klickhouse/src/values/mod.rs
+++ b/klickhouse/src/values/mod.rs
@@ -15,12 +15,14 @@ mod date;
 #[cfg(feature = "rust_decimal")]
 mod decimal;
 mod fixed_point;
+mod geo;
 mod int256;
 mod ip;
 
 pub use bytes::*;
 pub use date::*;
 pub use fixed_point::*;
+pub use geo::*;
 pub use int256::*;
 pub use ip::*;
 
@@ -76,6 +78,11 @@ pub enum Value {
 
     Ipv4(Ipv4),
     Ipv6(Ipv6),
+
+    Point(Point),
+    Ring(Ring),
+    Polygon(Polygon),
+    MultiPolygon(MultiPolygon),
 }
 
 impl PartialEq for Value {
@@ -111,6 +118,10 @@ impl PartialEq for Value {
             (Self::Map(l0, l1), Self::Map(r0, r1)) => l0 == r0 && l1 == r1,
             (Self::Ipv4(l0), Self::Ipv4(r0)) => l0 == r0,
             (Self::Ipv6(l0), Self::Ipv6(r0)) => l0 == r0,
+            (Self::Point(l0), Self::Point(r0)) => l0 == r0,
+            (Self::Ring(l0), Self::Ring(r0)) => l0 == r0,
+            (Self::Polygon(l0), Self::Polygon(r0)) => l0 == r0,
+            (Self::MultiPolygon(l0), Self::MultiPolygon(r0)) => l0 == r0,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }
@@ -167,6 +178,12 @@ impl Hash for Value {
             }
             Value::Ipv4(x) => ::core::hash::Hash::hash(x, state),
             Value::Ipv6(x) => ::core::hash::Hash::hash(x, state),
+
+            Value::Point(x) => ::core::hash::Hash::hash(x, state),
+            Value::Ring(x) => ::core::hash::Hash::hash(x, state),
+            Value::Polygon(x) => ::core::hash::Hash::hash(x, state),
+            Value::MultiPolygon(x) => ::core::hash::Hash::hash(x, state),
+
             _ => {}
         }
     }
@@ -274,6 +291,11 @@ impl Value {
             ),
             Value::Ipv4(_) => Type::Ipv4,
             Value::Ipv6(_) => Type::Ipv6,
+
+            Value::Point(_) => Type::Point,
+            Value::Ring(_) => Type::Ring,
+            Value::Polygon(_) => Type::Polygon,
+            Value::MultiPolygon(_) => Type::MultiPolygon,
         }
     }
 }
@@ -424,6 +446,10 @@ impl fmt::Display for Value {
             }
             Value::Ipv4(ipv4) => write!(f, "'{ipv4}'"),
             Value::Ipv6(ipv6) => write!(f, "'{ipv6}'"),
+            Value::Point(x) => write!(f, "{:?}", x),
+            Value::Ring(x) => write!(f, "{:?}", x),
+            Value::Polygon(x) => write!(f, "{:?}", x),
+            Value::MultiPolygon(x) => write!(f, "{:?}", x),
         }
     }
 }

--- a/klickhouse/src/values/tests.rs
+++ b/klickhouse/src/values/tests.rs
@@ -7,6 +7,7 @@ use crate::{
     i256,
     types::Type,
     u256, Date, DateTime, DateTime64, FixedPoint128, FixedPoint256, FixedPoint32, FixedPoint64,
+    MultiPolygon, Point, Polygon, Ring,
 };
 
 use super::Value;
@@ -492,5 +493,27 @@ fn test_escape() {
     assert_eq!(
         Value::string("te\u{1F60A}st").to_string(),
         "'te\\xF0\\x9F\\x98\\x8Ast'"
+    );
+}
+
+#[tokio::test]
+async fn roundtrip_geo() {
+    // Points
+    let point = Point([1.0, 2.0]);
+    assert_eq!(&point, &roundtrip(point.clone(), &Type::Point));
+    // Ring
+    let ring = Ring(vec![point.clone(), Point([3.0, 4.0])]);
+    assert_eq!(&ring, &roundtrip(ring.clone(), &Type::Ring));
+    // Polygon
+    let polygon = Polygon(vec![ring.clone(), Ring(vec![Point([5.0, 6.0])])]);
+    assert_eq!(&polygon, &roundtrip(polygon.clone(), &Type::Polygon));
+    // Multipolygon
+    let multipolygon = MultiPolygon(vec![
+        polygon.clone(),
+        Polygon(vec![ring.clone(), Ring(vec![point])]),
+    ]);
+    assert_eq!(
+        &multipolygon,
+        &roundtrip(multipolygon.clone(), &Type::MultiPolygon)
     );
 }

--- a/klickhouse/tests/main.rs
+++ b/klickhouse/tests/main.rs
@@ -1,6 +1,7 @@
 pub mod test;
 pub mod test_bytes;
 pub mod test_decimal;
+pub mod test_geo;
 pub mod test_lock;
 pub mod test_nested;
 pub mod test_raw_string;

--- a/klickhouse/tests/test_geo.rs
+++ b/klickhouse/tests/test_geo.rs
@@ -1,0 +1,69 @@
+use klickhouse::{MultiPolygon, Point, Polygon, Ring};
+
+#[derive(klickhouse::Row, Debug, Default, PartialEq, Clone)]
+pub struct Row {
+    point: Point,
+    ring: Ring,
+    polygon: Polygon,
+    multipolygon: MultiPolygon,
+}
+
+#[tokio::test]
+#[allow(clippy::field_reassign_with_default)]
+async fn test_client() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+    let client = super::get_client().await;
+
+    super::prepare_table(
+        "test_geo",
+        r"
+        point Point,
+        ring Ring,
+        polygon Polygon,
+        multipolygon MultiPolygon",
+        &client,
+    )
+    .await;
+
+    println!("begin insert");
+
+    let mut items = Vec::with_capacity(2);
+
+    for i in 0..items.capacity() {
+        let i = i as f64;
+        let ring = Ring(vec![Point([i, i + 2.0]), Point([i + 3.0, i + 4.0])]);
+        let polygon = |j| {
+            Polygon(vec![
+                ring.clone(),
+                Ring(vec![
+                    Point([j + i + 5.0, j + i + 6.0]),
+                    Point([j + i + 7.0, j + i + 8.0]),
+                ]),
+            ])
+        };
+        let item = Row {
+            point: Point([i, i + 2.0]),
+            ring: ring.clone(),
+            polygon: polygon(0.0),
+            multipolygon: MultiPolygon(vec![polygon(0.0), polygon(10.0)]),
+        };
+
+        items.push(item);
+    }
+
+    client
+        .insert_native_block("INSERT INTO test_geo FORMAT Native", items.clone())
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let items2 = client
+        // String directly.
+        .query_collect::<Row>("SELECT * FROM test_geo")
+        .await
+        .unwrap();
+    assert_eq!(items, items2);
+}

--- a/klickhouse/tests/test_geo.rs
+++ b/klickhouse/tests/test_geo.rs
@@ -61,9 +61,43 @@ async fn test_client() {
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let items2 = client
-        // String directly.
         .query_collect::<Row>("SELECT * FROM test_geo")
         .await
         .unwrap();
     assert_eq!(items, items2);
+}
+
+#[derive(Clone, PartialEq, Debug, klickhouse::Row)]
+struct RowWkt {
+    multipolygon: MultiPolygon,
+}
+
+#[cfg(feature = "geo-types")]
+#[tokio::test]
+async fn test_client_wkt() {
+    let client = super::get_client().await;
+
+    super::prepare_table("test_geo_wkt", "multipolygon MultiPolygon", &client).await;
+    let multipolygon: geo_types::MultiPolygon = geo_types::wkt! {
+        // Example from https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
+        MULTIPOLYGON (((40.0 40.0, 20.0 45.0, 45.0 30.0, 40.0 40.0)),
+                      ((20.0 35.0, 10.0 30.0, 10.0 10.0, 30.0 5.0, 45.0 20.0, 20.0 35.0),
+                       (30.0 20.0, 20.0 15.0, 20.0 25.0, 30. 20.0)))
+    };
+    let row = RowWkt {
+        multipolygon: MultiPolygon::from(multipolygon),
+    };
+
+    client
+        .insert_native_block("INSERT INTO test_geo_wkt FORMAT Native", vec![row.clone()])
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let row2 = client
+        .query_one::<RowWkt>("SELECT * FROM test_geo_wkt")
+        .await
+        .unwrap();
+    assert_eq!(row2, row);
 }

--- a/klickhouse/tests/test_geo.rs
+++ b/klickhouse/tests/test_geo.rs
@@ -69,7 +69,7 @@ async fn test_client() {
 
 #[derive(Clone, PartialEq, Debug, klickhouse::Row)]
 struct RowWkt {
-    multipolygon: MultiPolygon,
+    multipolygon: geo_types::MultiPolygon,
 }
 
 #[cfg(feature = "geo-types")]
@@ -85,7 +85,7 @@ async fn test_client_wkt() {
                        (30.0 20.0, 20.0 15.0, 20.0 25.0, 30. 20.0)))
     };
     let row = RowWkt {
-        multipolygon: MultiPolygon::from(multipolygon),
+        multipolygon: multipolygon,
     };
 
     client


### PR DESCRIPTION
This adds support for native clickhouse geo data types: https://clickhouse.com/docs/en/sql-reference/data-types/geo
- `Point`
- `Ring`
- `Polygon`
- `MultiPolygon`

The approach taken is documented in https://github.com/Protryon/klickhouse/commit/1eb61fdd533e663d4daa85125d58fb8539db695e

The changes are tested with unit and integration tests.

In addition to these main changes, the README is updated to document all feature flags. It is now included in `lib.rs`, so that it will also display in the docs.rs documentation.

Alas it seems like Github does not support stacked PRs without the first PR being a branch of the original repo.
This is based on https://github.com/Protryon/klickhouse/pull/32, only the 5 commits from today are new compared to the first PR. A proper diff can be viewed here: https://github.com/Protryon/klickhouse/pull/33/files/30cafa6c49dbf91f6c2463aaeeafc28b09299855..6372019814c1479e791a63e827834c931fa4b0ad