### PR TITLE
Flattening in Row derive macro + documentation of attributes

### DIFF
--- a/klickhouse/src/block.rs
+++ b/klickhouse/src/block.rs
@@ -128,6 +128,9 @@ impl Iterator for BlockRowIntoIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut out = IndexMap::new();
+        if self.column_data.is_empty() {
+            return None;
+        }
         for (name, value) in self.column_data.iter_mut() {
             out.insert(name.clone(), value.pop_front()?);
         }

--- a/klickhouse/src/lib.rs
+++ b/klickhouse/src/lib.rs
@@ -36,6 +36,31 @@ pub use manager::ConnectionManager;
 pub use uuid::Uuid;
 
 #[cfg(feature = "derive")]
+/// Derive macro for the [Row] trait.
+///
+/// This is similar in usage and implementation to the [serde::Serialize] and [serde::Deserialize] derive macros.
+///
+/// ## serde attributes
+/// The following [serde attributes](https://serde.rs/attributes.html) are supported, using `#[klickhouse(...)]` instead of `#[serde(...)]`:
+/// - `with`
+/// - `from` and `into`
+/// - `try_from`
+/// - `skip`
+/// - `default`
+/// - `deny_unknown_fields`
+/// - `rename`
+/// - `rename_all`
+/// - `serialize_with`, `deserialize_with`
+/// - `skip_deserializing`, `skip_serializing`
+/// - `flatten`
+///    - Index-based matching is disabled (the column names must match exactly).
+///    - Due to the current interface of the [Row] trait, performance might not be optimal, as a value map must be reconstitued for each flattened subfield.
+///
+/// ## Clickhouse-specific attributes
+/// - The `nested` attribute allows handling [Clickhouse nested data structures](https://clickhouse.com/docs/en/sql-reference/data-types/nested-data-structures/nested). See an example in the `tests` folder.
+///
+/// ## Known issues
+/// - For serialization, the ordering of fields in the struct declaration must match the order in the `INSERT` statement, respectively in the table declaration. See issue [#34](https://github.com/Protryon/klickhouse/issues/34).
 pub use klickhouse_derive::Row;
 
 pub use client::*;

--- a/klickhouse/tests/main.rs
+++ b/klickhouse/tests/main.rs
@@ -1,6 +1,7 @@
 pub mod test;
 pub mod test_bytes;
 pub mod test_decimal;
+pub mod test_flatten;
 pub mod test_geo;
 pub mod test_lock;
 pub mod test_nested;

--- a/klickhouse/tests/test_flatten.rs
+++ b/klickhouse/tests/test_flatten.rs
@@ -1,0 +1,59 @@
+use klickhouse::Row;
+
+#[derive(klickhouse::Row, Debug, Default, PartialEq, Clone)]
+pub struct TestRow {
+    field: u32,
+    #[klickhouse(flatten)]
+    subrow: SubRow,
+    field2: u32,
+}
+
+#[derive(klickhouse::Row, Debug, Default, PartialEq, Clone)]
+pub struct SubRow {
+    a: u32,
+    b: f32,
+}
+
+#[tokio::test]
+async fn test_client() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    assert!(TestRow::column_names()
+        .unwrap()
+        .into_iter()
+        .zip(["field", "a", "b"])
+        .all(|(x, y)| x == y));
+
+    let client = super::get_client().await;
+
+    super::prepare_table(
+        "test_flatten",
+        "field UInt32,
+         field2 UInt32,
+         a UInt32,
+         b Float32",
+        &client,
+    )
+    .await;
+
+    let row = TestRow {
+        field: 1,
+        field2: 4,
+        subrow: SubRow { a: 2, b: 3.0 },
+    };
+
+    client
+        .insert_native_block("INSERT INTO test_flatten FORMAT Native", vec![row.clone()])
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let row2 = client
+        .query_one::<TestRow>("SELECT * FROM test_flatten")
+        .await
+        .unwrap();
+    assert_eq!(row, row2);
+}

--- a/klickhouse/tests/test_geo.rs
+++ b/klickhouse/tests/test_geo.rs
@@ -84,9 +84,7 @@ async fn test_client_wkt() {
                       ((20.0 35.0, 10.0 30.0, 10.0 10.0, 30.0 5.0, 45.0 20.0, 20.0 35.0),
                        (30.0 20.0, 20.0 15.0, 20.0 25.0, 30. 20.0)))
     };
-    let row = RowWkt {
-        multipolygon: multipolygon,
-    };
+    let row = RowWkt { multipolygon };
 
     client
         .insert_native_block("INSERT INTO test_geo_wkt FORMAT Native", vec![row.clone()])

--- a/klickhouse_derive/src/attr.rs
+++ b/klickhouse_derive/src/attr.rs
@@ -335,6 +335,7 @@ pub struct Field {
     deserialize_with: Option<syn::ExprPath>,
     bound: Option<Vec<syn::WherePredicate>>,
     nested: bool,
+    flatten: bool,
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -360,6 +361,7 @@ impl Field {
         let mut nested = BoolAttr::none(cx, NESTED);
         let mut skip_serializing = BoolAttr::none(cx, SKIP_SERIALIZING);
         let mut skip_deserializing = BoolAttr::none(cx, SKIP_DESERIALIZING);
+        let mut flatten = BoolAttr::none(cx, FLATTEN);
         let mut default = Attr::none(cx, DEFAULT);
         let mut serialize_with = Attr::none(cx, SERIALIZE_WITH);
         let mut deserialize_with = Attr::none(cx, DESERIALIZE_WITH);
@@ -404,6 +406,11 @@ impl Field {
                 // Parse `#[klickhouse(nested)]`
                 Meta(Path(word)) if word == NESTED => {
                     nested.set_true(word);
+                }
+
+                // Parse `#[klickhouse(flatten)]`
+                Meta(Path(word)) if word == FLATTEN => {
+                    flatten.set_true(word);
                 }
 
                 // Parse `#[klickhouse(skip_deserializing)]`
@@ -492,6 +499,7 @@ impl Field {
             deserialize_with: deserialize_with.get(),
             bound: bound.get(),
             nested: nested.get(),
+            flatten: flatten.get(),
         }
     }
 
@@ -503,6 +511,10 @@ impl Field {
         if !self.name.renamed {
             self.name.name = rules.apply_to_field(&self.name.name);
         }
+    }
+
+    pub fn flatten(&self) -> bool {
+        self.flatten
     }
 
     pub fn nested(&self) -> bool {

--- a/klickhouse_derive/src/symbol.rs
+++ b/klickhouse_derive/src/symbol.rs
@@ -8,6 +8,7 @@ pub const BOUND: Symbol = Symbol("bound");
 pub const DEFAULT: Symbol = Symbol("default");
 pub const DENY_UNKNOWN_FIELDS: Symbol = Symbol("deny_unknown_fields");
 pub const NESTED: Symbol = Symbol("nested");
+pub const FLATTEN: Symbol = Symbol("flatten");
 pub const DESERIALIZE_WITH: Symbol = Symbol("deserialize_with");
 pub const FROM: Symbol = Symbol("from");
 pub const INTO: Symbol = Symbol("into");


### PR DESCRIPTION
Following issue https://github.com/Protryon/klickhouse/issues/30, this implements the serde-like `flatten` attribute on the `Row` derive macro, allowing to compose rows as follows:
```rust
#[derive(klickhouse::Row)]
struct User {
  age: u8,
  name: string
}
#[derive(klickhouse::Row)]
struct Row {
  #[klickhouse(flatten)]
  user: User,
  credits: u32
}
let users: Vec<Row> = ch.query_collect("SELECT age, name, credits FROM ...").await?;
```

The commit also adds documentation on the derive macro, in particular::
- The supported serde- and clickhouse-specific attributes
- The issue on field ordering for type hints #34

This is stacked on PRs from #33 and #33 (tests and documentation). Only the last commit d58c63355c0bab01cbd6b9f9e520083a2b8be5cb is new. [See only new changes](https://github.com/Protryon/klickhouse/pull/35/commits/d58c63355c0bab01cbd6b9f9e520083a2b8be5cb).