### PR TITLE
Broadcast progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Clickhouse server is required to run the integration tests. One can be started
 ```
 $ docker run  --rm --name clickhouse -p 19000:9000 --ulimit nofile=262144:262144 clickhouse
 $ export KLICKHOUSE_TEST_ADDR=127.0.0.1:19000
-$ cargo nexttest run
+$ cargo nextest run
 ```
 
 (running the tests simultaneously with `cargo test` is currently not suported, due to loggers initializations.)

--- a/klickhouse/examples/basic.rs
+++ b/klickhouse/examples/basic.rs
@@ -2,13 +2,6 @@ use chrono::Utc;
 use futures::StreamExt;
 use klickhouse::*;
 
-/*
-create table my_user_data (
-    id UUID,
-    user_data String,
-    created_at DateTime('UTC')
-) Engine=Memory;
-*/
 #[derive(Row, Debug, Default)]
 pub struct MyUserData {
     id: Uuid,
@@ -25,19 +18,61 @@ async fn main() {
         .await
         .unwrap();
 
-    let row = MyUserData {
-        id: Uuid::new_v4(),
-        user_data: "some important stuff!".to_string(),
-        created_at: Utc::now().try_into().unwrap(),
-    };
+    // Retrieve and display query progress events
+    let mut progress = client.subscribe_progress();
+    let progress_task = tokio::task::spawn(async move {
+        let mut current_query = Uuid::nil();
+        let mut progress_total = Progress::default();
+        while let Ok((query, progress)) = progress.recv().await {
+            if query != current_query {
+                progress_total = Progress::default();
+                current_query = query;
+            }
+            progress_total += progress;
+            println!(
+                "Progress on query {}: {}/{} {:.2}%",
+                query,
+                progress_total.read_rows,
+                progress_total.new_total_rows_to_read,
+                100.0 * progress_total.read_rows as f64
+                    / progress_total.new_total_rows_to_read as f64
+            );
+        }
+    });
 
+    // Prepare table
     client
-        .insert_native_block("INSERT INTO my_user_data FORMAT native", vec![row])
+        .execute("DROP TABLE IF EXISTS klickhouse_example")
+        .await
+        .unwrap();
+    client
+        .execute(
+            "
+    CREATE TABLE klickhouse_example (
+         id UUID,
+         user_data String,
+         created_at DateTime('UTC'))
+     Engine=MergeTree() ORDER BY created_at;",
+        )
         .await
         .unwrap();
 
+    // Insert rows
+    let rows = (0..5)
+        .map(|_| MyUserData {
+            id: Uuid::new_v4(),
+            user_data: "some important stuff!".to_string(),
+            created_at: Utc::now().try_into().unwrap(),
+        })
+        .collect();
+    client
+        .insert_native_block("INSERT INTO klickhouse_example FORMAT native", rows)
+        .await
+        .unwrap();
+
+    // Read back rows
     let mut all_rows = client
-        .query::<MyUserData>("select * from my_user_data;")
+        .query::<MyUserData>("SELECT * FROM klickhouse_example;")
         .await
         .unwrap();
 
@@ -45,4 +80,8 @@ async fn main() {
         let row = row.unwrap();
         println!("row received '{}': {:?}", row.id, row);
     }
+
+    // Drop the client so that the progress task finishes.
+    drop(client);
+    progress_task.await.unwrap();
 }

--- a/klickhouse/src/lib.rs
+++ b/klickhouse/src/lib.rs
@@ -20,6 +20,7 @@ mod migrate;
 #[cfg(feature = "refinery")]
 pub use migrate::*;
 mod progress;
+pub use progress::*;
 mod protocol;
 mod query;
 pub mod query_parser;

--- a/klickhouse/src/migrate.rs
+++ b/klickhouse/src/migrate.rs
@@ -56,13 +56,13 @@ impl MigrationInner {
     }
 }
 
-impl Into<Migration> for MigrationInner {
-    fn into(self) -> Migration {
+impl From<MigrationInner> for Migration {
+    fn from(inner: MigrationInner) -> Self {
         assert_eq!(
             std::mem::size_of::<Migration>(),
             std::mem::size_of::<MigrationInner>()
         );
-        unsafe { std::mem::transmute(self) }
+        unsafe { std::mem::transmute(inner) }
     }
 }
 

--- a/klickhouse/src/progress.rs
+++ b/klickhouse/src/progress.rs
@@ -1,8 +1,37 @@
-#[derive(Debug, Clone, Copy)]
+/// Query execution progress.
+/// Values are delta and must be summed.
+///
+/// See https://clickhouse.com/codebrowser/ClickHouse/src/IO/Progress.h.html
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Progress {
     pub read_rows: u64,
     pub read_bytes: u64,
     pub new_total_rows_to_read: u64,
     pub new_written_rows: Option<u64>,
     pub new_written_bytes: Option<u64>,
+}
+impl std::ops::Add for Progress {
+    type Output = Progress;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let sum_opt = |opt1, opt2| match (opt1, opt2) {
+            (Some(a), Some(b)) => Some(a + b),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        Self::Output {
+            read_rows: self.read_rows + rhs.read_rows,
+            read_bytes: self.read_bytes + rhs.read_bytes,
+            new_total_rows_to_read: self.new_total_rows_to_read + rhs.new_total_rows_to_read,
+            new_written_rows: sum_opt(self.new_written_rows, rhs.new_written_rows),
+            new_written_bytes: sum_opt(self.new_written_bytes, rhs.new_written_bytes),
+        }
+    }
+}
+
+impl std::ops::AddAssign for Progress {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
 }

--- a/klickhouse/src/values/decimal.rs
+++ b/klickhouse/src/values/decimal.rs
@@ -12,7 +12,7 @@ impl FromSql for Decimal {
             Value::Int8(i) => Ok(Decimal::new(i as i64, 0)),
             Value::Int16(i) => Ok(Decimal::new(i as i64, 0)),
             Value::Int32(i) => Ok(Decimal::new(i as i64, 0)),
-            Value::Int64(i) => Ok(Decimal::new(i as i64, 0)),
+            Value::Int64(i) => Ok(Decimal::new(i, 0)),
             Value::Int128(i) => {
                 Decimal::try_from_i128_with_scale(i, 0).map_err(|_| out_of_range("i128"))
             }
@@ -79,9 +79,7 @@ impl ToSql for Decimal {
             Some(Type::Decimal128(precision)) if *precision as u32 >= scale => {
                 Ok(Value::Decimal128(
                     *precision,
-                    mantissa_to_scale(mantissa, scale, *precision as u32)?
-                        .try_into()
-                        .map_err(|_| out_of_range("Decimal128"))?,
+                    mantissa_to_scale(mantissa, scale, *precision as u32)?,
                 ))
             }
             Some(x) => Err(KlickhouseError::SerializeError(format!(

--- a/klickhouse_derive/src/row.rs
+++ b/klickhouse_derive/src/row.rs
@@ -111,6 +111,7 @@ pub fn expand_derive_serialize(
         #[automatically_derived]
         #[allow(clippy)]
         #[allow(non_snake_case)]
+        #[allow(clippy::absurd_extreme_comparisons)]
         impl #impl_generics ::klickhouse::Row for #ident #ty_generics #where_clause {
             const COLUMN_COUNT: ::std::option::Option<usize> = #const_column_count_fn();
 


### PR DESCRIPTION
This adds a `Client::subscribe_progress` method that allows subscribing to query progress events sent by the server. This is very useful to track the progress of larger queries. 

The implementation uses a `tokio::sync::broadcast`, which only keeps the most recent events and sends them to subscribers. It is pretty short given that the blocks were already parsed.

This was briefly mentioned in https://github.com/Protryon/klickhouse/issues/10#issuecomment-1314082474

## Tests
This was tested through the "basic" example, adapted to display progress, and against a real database.

## Matching progress against queries

Note that the `Client::query*` interfaces currently do not provide the ID of the query, so it is not yet possible to match progress events against exact queries. Nevertheless, the commit already populates the ID of queries, and returns it as part of the progress stream.

Later, The `Client::query*` should likely be adapted to return the query ID in addition to the Block stream. Then either:
- We keep the same `subscribe_progress` interface
- We return a progress stream for this exact query along with the query ID and the block stream.
- We change the stream be a stream of enum representing either `Block` or `Progress`.

An alternative is to add a method to `Client` to return the ID of the query currently executing; this would be almost trivial.