### PR TITLE
Change Row::serialize_row signature so that type hinting is independent of struct members declaration order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "klickhouse",
     "klickhouse_derive",
 ]
+resolver = "2"

--- a/klickhouse/src/client.rs
+++ b/klickhouse/src/client.rs
@@ -414,9 +414,8 @@ impl Client {
                 column_types: first_block.column_types.clone(),
                 column_data: IndexMap::new(),
             };
-            let types = first_block.column_types.values().collect::<Vec<_>>();
             rows.into_iter()
-                .map(|x| x.serialize_row(&types[..]))
+                .map(|x| x.serialize_row(&first_block.column_types))
                 .filter_map(|x| match x {
                     Err(e) => {
                         error!("serialization error during insert (SKIPPED ROWS!): {:?}", e);

--- a/klickhouse/src/convert/mod.rs
+++ b/klickhouse/src/convert/mod.rs
@@ -53,5 +53,8 @@ pub trait Row: Sized {
 
     fn deserialize_row(map: Vec<(&str, &Type, Value)>) -> Result<Self>;
 
-    fn serialize_row(self, type_hints: &[&Type]) -> Result<Vec<(Cow<'static, str>, Value)>>;
+    fn serialize_row(
+        self,
+        type_hints: &indexmap::IndexMap<String, Type>,
+    ) -> Result<Vec<(Cow<'static, str>, Value)>>;
 }

--- a/klickhouse/src/convert/raw_row.rs
+++ b/klickhouse/src/convert/raw_row.rs
@@ -22,7 +22,10 @@ impl Row for RawRow {
         ))
     }
 
-    fn serialize_row(self, _type_hints: &[&Type]) -> Result<Vec<(Cow<'static, str>, Value)>> {
+    fn serialize_row(
+        self,
+        _type_hints: &indexmap::IndexMap<String, Type>,
+    ) -> Result<Vec<(Cow<'static, str>, Value)>> {
         Ok(self
             .0
             .into_iter()

--- a/klickhouse/src/convert/unit_value.rs
+++ b/klickhouse/src/convert/unit_value.rs
@@ -21,10 +21,13 @@ impl<T: FromSql + ToSql> Row for UnitValue<T> {
         T::from_sql(item.1, item.2).map(UnitValue)
     }
 
-    fn serialize_row(self, type_hints: &[&Type]) -> Result<Vec<(Cow<'static, str>, Value)>> {
+    fn serialize_row(
+        self,
+        type_hints: &indexmap::IndexMap<String, Type>,
+    ) -> Result<Vec<(Cow<'static, str>, Value)>> {
         Ok(vec![(
             Cow::Borrowed("_"),
-            self.0.to_sql(type_hints.first().copied())?,
+            self.0.to_sql(type_hints.values().next())?,
         )])
     }
 }

--- a/klickhouse/src/convert/unit_value.rs
+++ b/klickhouse/src/convert/unit_value.rs
@@ -24,7 +24,7 @@ impl<T: FromSql + ToSql> Row for UnitValue<T> {
     fn serialize_row(self, type_hints: &[&Type]) -> Result<Vec<(Cow<'static, str>, Value)>> {
         Ok(vec![(
             Cow::Borrowed("_"),
-            self.0.to_sql(type_hints.get(0).copied())?,
+            self.0.to_sql(type_hints.first().copied())?,
         )])
     }
 }

--- a/klickhouse/src/lib.rs
+++ b/klickhouse/src/lib.rs
@@ -35,6 +35,8 @@ pub use manager::ConnectionManager;
 
 pub use uuid::Uuid;
 
+pub use indexmap::IndexMap;
+
 #[cfg(feature = "derive")]
 /// Derive macro for the [Row] trait.
 ///

--- a/klickhouse/src/migrate.rs
+++ b/klickhouse/src/migrate.rs
@@ -165,7 +165,10 @@ impl Row for Migration {
         .into())
     }
 
-    fn serialize_row(self, _type_hints: &[&Type]) -> Result<Vec<(Cow<'static, str>, Value)>> {
+    fn serialize_row(
+        self,
+        _type_hints: &indexmap::IndexMap<String, Type>,
+    ) -> Result<Vec<(Cow<'static, str>, Value)>> {
         unimplemented!()
     }
 }

--- a/klickhouse/src/values/date.rs
+++ b/klickhouse/src/values/date.rs
@@ -149,7 +149,7 @@ impl TryFrom<DateTime> for chrono::DateTime<Tz> {
     type Error = TryFromIntError;
 
     fn try_from(date: DateTime) -> Result<Self, TryFromIntError> {
-        Ok(date.0.timestamp_opt(date.1.try_into()?, 0).unwrap())
+        Ok(date.0.timestamp_opt(date.1.into(), 0).unwrap())
     }
 }
 
@@ -159,7 +159,7 @@ impl TryFrom<DateTime> for chrono::DateTime<FixedOffset> {
     fn try_from(date: DateTime) -> Result<Self, TryFromIntError> {
         Ok(date
             .0
-            .timestamp_opt(date.1.try_into()?, 0)
+            .timestamp_opt(date.1.into(), 0)
             .unwrap()
             .fixed_offset())
     }
@@ -171,7 +171,7 @@ impl TryFrom<DateTime> for chrono::DateTime<Utc> {
     fn try_from(date: DateTime) -> Result<Self, TryFromIntError> {
         Ok(date
             .0
-            .timestamp_opt(date.1.try_into()?, 0)
+            .timestamp_opt(date.1.into(), 0)
             .unwrap()
             .with_timezone(&Utc))
     }

--- a/klickhouse/src/values/decimal.rs
+++ b/klickhouse/src/values/decimal.rs
@@ -19,11 +19,9 @@ impl FromSql for Decimal {
             Value::UInt8(i) => Ok(Decimal::new(i as i64, 0)),
             Value::UInt16(i) => Ok(Decimal::new(i as i64, 0)),
             Value::UInt32(i) => Ok(Decimal::new(i as i64, 0)),
-            Value::UInt64(i) => Decimal::try_from_i128_with_scale(
-                i.try_into().map_err(|_| out_of_range("u128"))?,
-                0,
-            )
-            .map_err(|_| out_of_range("u128")),
+            Value::UInt64(i) => {
+                Decimal::try_from_i128_with_scale(i.into(), 0).map_err(|_| out_of_range("u128"))
+            }
             Value::UInt128(i) => Decimal::try_from_i128_with_scale(
                 i.try_into().map_err(|_| out_of_range("u128"))?,
                 0,

--- a/klickhouse/src/values/mod.rs
+++ b/klickhouse/src/values/mod.rs
@@ -413,7 +413,7 @@ impl fmt::Display for Value {
             Value::Enum16(x) => write!(f, "{x}"),
             Value::Array(array) => {
                 write!(f, "[")?;
-                if let Some(item) = array.get(0) {
+                if let Some(item) = array.first() {
                     write!(f, "{}", item)?;
                 }
                 for item in array.iter().skip(1) {
@@ -423,7 +423,7 @@ impl fmt::Display for Value {
             }
             Value::Tuple(tuple) => {
                 write!(f, "(")?;
-                if let Some(item) = tuple.get(0) {
+                if let Some(item) = tuple.first() {
                     write!(f, "{}", item)?;
                 }
                 for item in tuple.iter().skip(1) {

--- a/klickhouse/tests/main.rs
+++ b/klickhouse/tests/main.rs
@@ -2,6 +2,7 @@ pub mod test;
 pub mod test_bytes;
 pub mod test_decimal;
 pub mod test_flatten;
+#[cfg(feature = "geo-types")]
 pub mod test_geo;
 pub mod test_lock;
 pub mod test_nested;

--- a/klickhouse/tests/main.rs
+++ b/klickhouse/tests/main.rs
@@ -6,6 +6,7 @@ pub mod test_flatten;
 pub mod test_geo;
 pub mod test_lock;
 pub mod test_nested;
+pub mod test_ordering;
 pub mod test_raw_string;
 pub mod test_serialize;
 

--- a/klickhouse/tests/test_ordering.rs
+++ b/klickhouse/tests/test_ordering.rs
@@ -1,0 +1,35 @@
+#[derive(klickhouse::Row, Debug, PartialEq, Clone)]
+struct TestRow {
+    b: klickhouse::Bytes,
+    a: klickhouse::Bytes,
+}
+
+// This test checks that the order of declaration in the struct does not matter for type hinting.
+// See https://github.com/Protryon/klickhouse/issues/34
+#[tokio::test]
+async fn ordering() {
+    let client = super::get_client().await;
+
+    super::prepare_table(
+        "test_ordering",
+        "a Array(UInt8),
+         b String",
+        &client,
+    )
+    .await;
+
+    let row = TestRow {
+        a: vec![1, 2, 3].into(),
+        b: vec![4, 5, 6].into(),
+    };
+    client
+        .insert_native_block("INSERT INTO test_ordering FORMAT Native", vec![row.clone()])
+        .await
+        .unwrap();
+
+    let row2 = client
+        .query_one("SELECT * from test_ordering")
+        .await
+        .unwrap();
+    assert_eq!(row, row2);
+}


### PR DESCRIPTION
This addresses #34.

This changes the `Row` trait and will require a minor version bump.

All tests pass (including the new one), clippy and doc as well.