### PR TITLE
Fix incorrect precision bounds for Decimal256.

### DIFF
--- a/klickhouse/src/types/mod.rs
+++ b/klickhouse/src/types/mod.rs
@@ -818,7 +818,7 @@ impl Type {
                 }
             }
             Type::Decimal256(precision) => {
-                if *precision == 0 || *precision > 9 {
+                if *precision == 0 || *precision > 76 {
                     return Err(KlickhouseError::TypeParseError(format!(
                         "precision out of bounds for Decimal256({}) must be in range (1..=76)",
                         *precision


### PR DESCRIPTION
The error message says it needs to be in range (1..=76), but the code checks it's in range (1..=9). Probably a copy/paste mistake with Decimal32.