### PR TITLE
Track MSRV in Cargo.toml

### DIFF
--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -9,6 +9,7 @@ description = "Klickhouse is a pure Rust SDK for working with Clickhouse with th
 keywords = [ "clickhouse", "database", "tokio", "sql" ]
 readme = "../README.md"
 autotests = false
+rust-version = "1.75.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/klickhouse_derive/Cargo.toml
+++ b/klickhouse_derive/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Protryon/klickhouse"
 description = "proc-macro crate for klickhouse"
 keywords = [ "clickhouse", "database", "tokio", "sql" ]
+rust-version = "1.75.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
It is worth specifying explicitly what minimum version the package supports. I chose 1.75 as the default because you can get rid of a lot of async-trait usage here, it will be in another PR.