### PR TITLE
Independent of libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,6 @@ dependencies = [
  "geo-types",
  "indexmap",
  "klickhouse_derive",
- "libc",
  "log",
  "lz4",
  "paste",

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -33,7 +33,6 @@ chrono = "0.4"
 chrono-tz = "0.8"
 futures = "0.3"
 tokio-stream = "0.1"
-libc = "0.2"
 lz4 = { version = "1.24", optional = true }
 klickhouse_derive = { version = "=0.12.0", optional = true, path = "../klickhouse_derive" }
 cityhash-rs = "1.0"

--- a/klickhouse/src/compression.rs
+++ b/klickhouse/src/compression.rs
@@ -11,6 +11,9 @@ use crate::io::ClickhouseRead;
 use crate::protocol::CompressionMethod;
 use crate::{KlickhouseError, Result};
 
+#[allow(non_camel_case_types)]
+type c_char = i8;
+
 pub async fn compress_block(block: Block, revision: u64) -> Result<(Vec<u8>, usize)> {
     let mut raw = vec![];
     block.write(&mut raw, revision).await?;
@@ -18,8 +21,8 @@ pub async fn compress_block(block: Block, revision: u64) -> Result<(Vec<u8>, usi
     let mut compressed = Vec::<u8>::with_capacity(raw.len() + (raw.len() / 255) + 16 + 1);
     let out_len = unsafe {
         lz4::liblz4::LZ4_compress_default(
-            raw.as_ptr() as *const libc::c_char,
-            compressed.as_mut_ptr() as *mut libc::c_char,
+            raw.as_ptr() as *const c_char,
+            compressed.as_mut_ptr() as *mut c_char,
             raw.len() as i32,
             compressed.capacity() as i32,
         )
@@ -42,8 +45,8 @@ pub fn decompress_block(data: &[u8], decompressed_size: u32) -> Result<Vec<u8>> 
 
     let out_len = unsafe {
         lz4::liblz4::LZ4_decompress_safe(
-            data.as_ptr() as *const libc::c_char,
-            output.as_mut_ptr() as *mut libc::c_char,
+            data.as_ptr() as *const c_char,
+            output.as_mut_ptr() as *mut c_char,
             data.len() as i32,
             output.capacity() as i32,
         )


### PR DESCRIPTION
This change allows us to not depend directly on `libc`. Since a simple type cast, which is an alias, is required. If something happens after update, the compiler will help us.