### PR TITLE
Use futures-util and std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,28 +498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -527,40 +511,6 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.57",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
@@ -576,11 +526,7 @@ checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -735,7 +681,7 @@ dependencies = [
  "compiler-tools",
  "compiler-tools-derive",
  "env_logger",
- "futures",
+ "futures-util",
  "geo-types",
  "indexmap",
  "klickhouse_derive",

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = { version = "2.2" }
 uuid = { version = "1.8", features = ["v4"] }
 chrono = "0.4"
 chrono-tz = "0.8"
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 tokio-stream = "0.1"
 libc = "0.2"
 lz4 = { version = "1.24", optional = true }

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = { version = "2.2" }
 uuid = { version = "1.8", features = ["v4"] }
 chrono = "0.4"
 chrono-tz = "0.8"
-futures-util = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tokio-stream = "0.1"
 libc = "0.2"
 lz4 = { version = "1.24", optional = true }

--- a/klickhouse/examples/basic.rs
+++ b/klickhouse/examples/basic.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use klickhouse::*;
 
 #[derive(Row, Debug, Default)]

--- a/klickhouse/examples/pool.rs
+++ b/klickhouse/examples/pool.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use klickhouse::*;
 
 #[derive(Row, Debug, Default)]

--- a/klickhouse/src/client.rs
+++ b/klickhouse/src/client.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use futures::{stream, Stream, StreamExt};
+use futures_util::{stream, Stream, StreamExt};
 use indexmap::IndexMap;
 use protocol::CompressionMethod;
 use tokio::{
@@ -459,7 +459,7 @@ impl Client {
         blocks: Vec<T>,
     ) -> Result<()> {
         let blocks = Box::pin(async move { blocks });
-        let stream = futures::stream::once(blocks);
+        let stream = futures_util::stream::once(blocks);
         self.insert_native(query, stream).await
     }
 

--- a/klickhouse/src/compression.rs
+++ b/klickhouse/src/compression.rs
@@ -1,8 +1,9 @@
+use std::future::Future;
 use std::io::ErrorKind;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::{Future, FutureExt};
+use futures_util::FutureExt;
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
 use crate::block::Block;

--- a/klickhouse/src/io.rs
+++ b/klickhouse/src/io.rs
@@ -1,4 +1,5 @@
-use futures::Future;
+use std::future::Future;
+
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{KlickhouseError, Result};

--- a/klickhouse/src/types/mod.rs
+++ b/klickhouse/src/types/mod.rs
@@ -1,7 +1,8 @@
+use std::future::Future;
 use std::{fmt::Display, str::FromStr};
 
 pub use chrono_tz::Tz;
-use futures::{Future, FutureExt};
+use futures_util::FutureExt;
 use uuid::Uuid;
 
 mod deserialize;


### PR DESCRIPTION
Instead of depending entirely on the `futures` library all that is needed is `futures-util` and the `Future` trait from `std`.