### PR TITLE
fix: #64 use std::ffi::c_char instead of local defined c_char i8 to f…

### DIFF
--- a/klickhouse/src/compression.rs
+++ b/klickhouse/src/compression.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_char;
 use std::future::Future;
 use std::io::ErrorKind;
 use std::pin::Pin;
@@ -11,9 +12,6 @@ use crate::internal_client_in::MAX_COMPRESSION_SIZE;
 use crate::io::ClickhouseRead;
 use crate::protocol::CompressionMethod;
 use crate::{KlickhouseError, Result};
-
-#[allow(non_camel_case_types)]
-type c_char = i8;
 
 pub async fn compress_block(block: Block, revision: u64) -> Result<(Vec<u8>, usize)> {
     let mut raw = vec![];


### PR DESCRIPTION
…ix lz4::liblz4::LZ4_compress_default E0308 compile error in aarch64 docker build

should fix: https://github.com/Protryon/klickhouse/issues/64