### PR TITLE
Missing type hints for into

### DIFF
--- a/klickhouse/tests/main.rs
+++ b/klickhouse/tests/main.rs
@@ -4,6 +4,7 @@ pub mod test_decimal;
 pub mod test_flatten;
 #[cfg(feature = "geo-types")]
 pub mod test_geo;
+pub mod test_into;
 pub mod test_lock;
 pub mod test_nested;
 pub mod test_ordering;

--- a/klickhouse/tests/test_into.rs
+++ b/klickhouse/tests/test_into.rs
@@ -1,0 +1,48 @@
+#[derive(klickhouse::Row, Debug, Default, PartialEq, Clone)]
+#[klickhouse(into = "TestType2")]
+pub struct TestType1 {
+    d_i8: i8,
+}
+
+impl Into<TestType2> for TestType1 {
+    fn into(self) -> TestType2 {
+        TestType2 {
+            d_i16: self.d_i8 as i16,
+        }
+    }
+}
+
+#[derive(klickhouse::Row, Debug, Default, PartialEq, Clone)]
+pub struct TestType2 {
+    d_i16: i16,
+}
+
+#[tokio::test]
+async fn test_client() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .try_init();
+    let client = super::get_client().await;
+
+    super::prepare_table(
+        "test_into",
+        r"
+        d_i16 Int16 default 0,
+    ",
+        &client,
+    )
+    .await;
+
+    println!("begin insert");
+
+    let block = TestType2::default();
+    client
+        .insert_native_block("insert into test_into format native", vec![block.clone()])
+        .await
+        .unwrap();
+
+    let block2 = client.query_one("SELECT * from test_into").await.unwrap();
+    assert_eq!(block, block2);
+
+    println!("done");
+}

--- a/klickhouse_derive/src/row.rs
+++ b/klickhouse_derive/src/row.rs
@@ -228,7 +228,8 @@ fn serialize_into(params: &Parameters, type_into: &syn::Type) -> Fragment {
     let self_var = &params.self_var;
     quote_block! {
         ::klickhouse::Row::serialize_row(
-            &::std::convert::Into::<#type_into>::into(#self_var)
+            ::std::convert::Into::<#type_into>::into(#self_var),
+            &type_hints
         )
     }
 }


### PR DESCRIPTION
I think you forgot to add `&type_hints` and to use the value not the reference for converting types.