### PR TITLE
Make Block::read and Block::write public

### DIFF
--- a/klickhouse/src/block.rs
+++ b/klickhouse/src/block.rs
@@ -177,7 +177,7 @@ impl Block {
         }
     }
 
-    pub(crate) async fn read<R: ClickhouseRead>(reader: &mut R, revision: u64) -> Result<Self> {
+    pub async fn read<R: ClickhouseRead>(reader: &mut R, revision: u64) -> Result<Self> {
         let info = if revision > 0 {
             BlockInfo::read(reader).await?
         } else {
@@ -211,11 +211,7 @@ impl Block {
         Ok(block)
     }
 
-    pub(crate) async fn write<W: ClickhouseWrite>(
-        mut self,
-        writer: &mut W,
-        revision: u64,
-    ) -> Result<()> {
+    pub async fn write<W: ClickhouseWrite>(mut self, writer: &mut W, revision: u64) -> Result<()> {
         if revision > 0 {
             self.info.write(writer).await?;
         }


### PR DESCRIPTION
This is a follow-up to https://github.com/Protryon/klickhouse/issues/28. It allows other crates to construct `Block`s from data.

I use `Block::read` functions in https://github.com/cpg314/polarhouse ([here](https://github.com/cpg314/polarhouse/blob/2368bde9aa79ad690f5f482e3d0bd2a3b0abaff3/src/clickhouse.rs#L217)) and having this merged would allow me to release the crate on crate.io