### PR TITLE
Support BFloat16 Data Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +554,17 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "serde",
+]
 
 [[package]]
 name = "hashbrown"
@@ -790,6 +807,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "geo-types",
+ "half",
  "indexmap",
  "klickhouse_derive",
  "log",

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -49,6 +49,7 @@ tokio-rustls = { version = "0.26", optional = true }
 rustls-pki-types = { version = "1.12", optional = true }
 paste = "1.0"
 geo-types = { version = "0.7", optional = true}
+half = "2.4"
 
 [dev-dependencies]
 tokio = { version = "1.45", features = ["rt-multi-thread"] }
@@ -60,7 +61,7 @@ derive = ["klickhouse_derive"]
 compression = ["lz4"]
 geo-types = ["dep:geo-types"]
 refinery = ["refinery-core", "time", "dep:async-trait"]
-serde = ["dep:serde", "serde_json", "uuid/serde", "chrono/serde"]
+serde = ["dep:serde", "serde_json", "uuid/serde", "chrono/serde", "half/serde"]
 tls = ["tokio-rustls", "rustls-pki-types"]
 bb8 = ["dep:bb8"]
 

--- a/klickhouse/Cargo.toml
+++ b/klickhouse/Cargo.toml
@@ -49,21 +49,22 @@ tokio-rustls = { version = "0.26", optional = true }
 rustls-pki-types = { version = "1.12", optional = true }
 paste = "1.0"
 geo-types = { version = "0.7", optional = true}
-half = "2.4"
+half = { version = "2.4", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.45", features = ["rt-multi-thread"] }
 env_logger = "0.11"
 
 [features]
-default = ["derive", "compression", "serde"]
+default = ["derive", "compression", "serde", "bfloat16"]
 derive = ["klickhouse_derive"]
 compression = ["lz4"]
 geo-types = ["dep:geo-types"]
 refinery = ["refinery-core", "time", "dep:async-trait"]
-serde = ["dep:serde", "serde_json", "uuid/serde", "chrono/serde", "half/serde"]
+serde = ["dep:serde", "serde_json", "uuid/serde", "chrono/serde", "half?/serde"]
 tls = ["tokio-rustls", "rustls-pki-types"]
 bb8 = ["dep:bb8"]
+bfloat16 = ["dep:half"]
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/klickhouse/src/convert/std_deserialize.rs
+++ b/klickhouse/src/convert/std_deserialize.rs
@@ -4,7 +4,8 @@ use std::{
     hash::Hash,
 };
 
-use half::bf16;
+#[cfg(feature = "bfloat16")]
+use crate::bf16;
 use indexmap::IndexMap;
 
 use super::*;
@@ -165,6 +166,7 @@ impl FromSql for f64 {
     }
 }
 
+#[cfg(feature = "bfloat16")]
 impl FromSql for bf16 {
     fn from_sql(type_: &Type, value: Value) -> Result<Self> {
         if !matches!(type_, Type::BFloat16) {

--- a/klickhouse/src/convert/std_deserialize.rs
+++ b/klickhouse/src/convert/std_deserialize.rs
@@ -4,6 +4,7 @@ use std::{
     hash::Hash,
 };
 
+use half::bf16;
 use indexmap::IndexMap;
 
 use super::*;
@@ -159,6 +160,18 @@ impl FromSql for f64 {
         }
         match value {
             Value::Float64(x) => Ok(x),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl FromSql for bf16 {
+    fn from_sql(type_: &Type, value: Value) -> Result<Self> {
+        if !matches!(type_, Type::BFloat16) {
+            return Err(unexpected_type(type_));
+        }
+        match value {
+            Value::BFloat16(x) => Ok(x),
             _ => unimplemented!(),
         }
     }

--- a/klickhouse/src/convert/std_deserialize.rs
+++ b/klickhouse/src/convert/std_deserialize.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 #[cfg(feature = "bfloat16")]
-use crate::bf16;
+use crate::values::bf16;
 use indexmap::IndexMap;
 
 use super::*;

--- a/klickhouse/src/convert/std_serialize.rs
+++ b/klickhouse/src/convert/std_serialize.rs
@@ -3,10 +3,12 @@ use std::{
     collections::{BTreeMap, HashMap},
 };
 
-use half::bf16;
 use indexmap::IndexMap;
 
 use super::*;
+
+#[cfg(feature = "bfloat16")]
+use crate::bf16;
 
 impl ToSql for u8 {
     fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
@@ -86,6 +88,7 @@ impl ToSql for f64 {
     }
 }
 
+#[cfg(feature = "bfloat16")]
 impl ToSql for bf16 {
     fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
         Ok(Value::BFloat16(self))

--- a/klickhouse/src/convert/std_serialize.rs
+++ b/klickhouse/src/convert/std_serialize.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use super::*;
 
 #[cfg(feature = "bfloat16")]
-use crate::bf16;
+use crate::values::bf16;
 
 impl ToSql for u8 {
     fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {

--- a/klickhouse/src/convert/std_serialize.rs
+++ b/klickhouse/src/convert/std_serialize.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{BTreeMap, HashMap},
 };
 
+use half::bf16;
 use indexmap::IndexMap;
 
 use super::*;
@@ -82,6 +83,12 @@ impl ToSql for f32 {
 impl ToSql for f64 {
     fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
         Ok(Value::Float64(self))
+    }
+}
+
+impl ToSql for bf16 {
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::BFloat16(self))
     }
 }
 

--- a/klickhouse/src/types/deserialize/sized.rs
+++ b/klickhouse/src/types/deserialize/sized.rs
@@ -1,6 +1,5 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use half::bf16;
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
@@ -44,7 +43,7 @@ impl Deserializer for SizedDeserializer {
                 }
                 Type::Float32 => Value::Float32(f32::from_bits(reader.read_u32_le().await?)),
                 Type::Float64 => Value::Float64(f64::from_bits(reader.read_u64_le().await?)),
-                Type::BFloat16 => Value::BFloat16(bf16::from_bits(reader.read_u16_le().await?)),
+                Type::BFloat16 => crate::deserialize_bf16_from_bits(reader.read_u16_le().await?),
                 Type::Decimal32(s) => Value::Decimal32(*s, reader.read_i32_le().await?),
                 Type::Decimal64(s) => Value::Decimal64(*s, reader.read_i64_le().await?),
                 Type::Decimal128(s) => Value::Decimal128(*s, reader.read_i128_le().await?),

--- a/klickhouse/src/types/deserialize/sized.rs
+++ b/klickhouse/src/types/deserialize/sized.rs
@@ -1,5 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+use half::bf16;
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
@@ -43,6 +44,7 @@ impl Deserializer for SizedDeserializer {
                 }
                 Type::Float32 => Value::Float32(f32::from_bits(reader.read_u32_le().await?)),
                 Type::Float64 => Value::Float64(f64::from_bits(reader.read_u64_le().await?)),
+                Type::BFloat16 => Value::BFloat16(bf16::from_bits(reader.read_u16_le().await?)),
                 Type::Decimal32(s) => Value::Decimal32(*s, reader.read_i32_le().await?),
                 Type::Decimal64(s) => Value::Decimal64(*s, reader.read_i64_le().await?),
                 Type::Decimal128(s) => Value::Decimal128(*s, reader.read_i128_le().await?),

--- a/klickhouse/src/types/deserialize/sized.rs
+++ b/klickhouse/src/types/deserialize/sized.rs
@@ -3,7 +3,10 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
-use crate::{i256, io::ClickhouseRead, u256, values::Value, Date, DateTime, DynDateTime64, Result};
+use crate::{
+    deserialize_bf16_from_bits, i256, io::ClickhouseRead, u256, values::Value, Date, DateTime,
+    DynDateTime64, Result,
+};
 
 use super::{Deserializer, DeserializerState, Type};
 
@@ -43,7 +46,7 @@ impl Deserializer for SizedDeserializer {
                 }
                 Type::Float32 => Value::Float32(f32::from_bits(reader.read_u32_le().await?)),
                 Type::Float64 => Value::Float64(f64::from_bits(reader.read_u64_le().await?)),
-                Type::BFloat16 => crate::deserialize_bf16_from_bits(reader.read_u16_le().await?),
+                Type::BFloat16 => deserialize_bf16_from_bits(reader.read_u16_le().await?),
                 Type::Decimal32(s) => Value::Decimal32(*s, reader.read_i32_le().await?),
                 Type::Decimal64(s) => Value::Decimal64(*s, reader.read_i64_le().await?),
                 Type::Decimal128(s) => Value::Decimal128(*s, reader.read_i128_le().await?),

--- a/klickhouse/src/types/mod.rs
+++ b/klickhouse/src/types/mod.rs
@@ -3,6 +3,7 @@ use std::{fmt::Display, str::FromStr};
 
 pub use chrono_tz::Tz;
 use futures_util::FutureExt;
+use half::bf16;
 use uuid::Uuid;
 
 mod deserialize;
@@ -39,6 +40,7 @@ pub enum Type {
 
     Float32,
     Float64,
+    BFloat16,
 
     Decimal32(usize),
     Decimal64(usize),
@@ -159,6 +161,7 @@ impl Type {
             Type::UInt256 => Value::UInt256(u256::default()),
             Type::Float32 => Value::Float32(0.0),
             Type::Float64 => Value::Float64(0.0),
+            Type::BFloat16 => Value::BFloat16(bf16::ZERO),
             Type::Decimal32(s) => Value::Decimal32(*s, 0),
             Type::Decimal64(s) => Value::Decimal64(*s, 0),
             Type::Decimal128(s) => Value::Decimal128(*s, 0),
@@ -466,6 +469,7 @@ impl FromStr for Type {
             "UInt256" => Type::UInt256,
             "Float32" => Type::Float32,
             "Float64" => Type::Float64,
+            "BFloat16" => Type::BFloat16,
             "String" => Type::String,
             "UUID" => Type::Uuid,
             "Date" => Type::Date,
@@ -502,6 +506,7 @@ impl Display for Type {
             Type::UInt256 => write!(f, "UInt256"),
             Type::Float32 => write!(f, "Float32"),
             Type::Float64 => write!(f, "Float64"),
+            Type::BFloat16 => write!(f, "BFloat16"),
             Type::Decimal32(s) => write!(f, "Decimal32({s})"),
             Type::Decimal64(s) => write!(f, "Decimal64({s})"),
             Type::Decimal128(s) => write!(f, "Decimal128({s})"),
@@ -578,6 +583,7 @@ impl Type {
                 | Type::UInt256
                 | Type::Float32
                 | Type::Float64
+                | Type::BFloat16
                 | Type::Decimal32(_)
                 | Type::Decimal64(_)
                 | Type::Decimal128(_)
@@ -653,6 +659,7 @@ impl Type {
                 | Type::UInt256
                 | Type::Float32
                 | Type::Float64
+                | Type::BFloat16
                 | Type::Decimal32(_)
                 | Type::Decimal64(_)
                 | Type::Decimal128(_)
@@ -717,6 +724,7 @@ impl Type {
                 | Type::UInt256
                 | Type::Float32
                 | Type::Float64
+                | Type::BFloat16
                 | Type::Decimal32(_)
                 | Type::Decimal64(_)
                 | Type::Decimal128(_)
@@ -785,6 +793,7 @@ impl Type {
                 | Type::UInt256
                 | Type::Float32
                 | Type::Float64
+                | Type::BFloat16
                 | Type::Decimal32(_)
                 | Type::Decimal64(_)
                 | Type::Decimal128(_)
@@ -968,7 +977,8 @@ impl Type {
             | (Type::UInt128, Value::UInt128(_))
             | (Type::UInt256, Value::UInt256(_))
             | (Type::Float32, Value::Float32(_))
-            | (Type::Float64, Value::Float64(_)) => true,
+            | (Type::Float64, Value::Float64(_))
+            | (Type::BFloat16, Value::BFloat16(_)) => true,
             (Type::Decimal32(precision1), Value::Decimal32(precision2, _)) => {
                 precision1 == precision2
             }

--- a/klickhouse/src/types/mod.rs
+++ b/klickhouse/src/types/mod.rs
@@ -12,8 +12,9 @@ mod serialize;
 mod tests;
 
 use crate::{
-    i256,
+    default_bf16_value, i256,
     io::{ClickhouseRead, ClickhouseWrite},
+    is_bfloat16_enabled,
     protocol::MAX_STRING_SIZE,
     u256,
     values::Value,
@@ -160,7 +161,7 @@ impl Type {
             Type::UInt256 => Value::UInt256(u256::default()),
             Type::Float32 => Value::Float32(0.0),
             Type::Float64 => Value::Float64(0.0),
-            Type::BFloat16 => crate::default_bf16_value(),
+            Type::BFloat16 => default_bf16_value(),
             Type::Decimal32(s) => Value::Decimal32(*s, 0),
             Type::Decimal64(s) => Value::Decimal64(*s, 0),
             Type::Decimal128(s) => Value::Decimal128(*s, 0),
@@ -469,7 +470,7 @@ impl FromStr for Type {
             "Float32" => Type::Float32,
             "Float64" => Type::Float64,
             "BFloat16" => {
-                if crate::is_bfloat16_enabled() {
+                if is_bfloat16_enabled() {
                     Type::BFloat16
                 } else {
                     return Err(KlickhouseError::TypeParseError("BFloat16 type is not supported. Enable the 'bfloat16' feature to use this type.".to_string()));
@@ -983,7 +984,7 @@ impl Type {
             | (Type::UInt256, Value::UInt256(_))
             | (Type::Float32, Value::Float32(_))
             | (Type::Float64, Value::Float64(_)) => true,
-            (Type::BFloat16, Value::BFloat16(_)) => crate::is_bfloat16_enabled(),
+            (Type::BFloat16, Value::BFloat16(_)) => is_bfloat16_enabled(),
             (Type::Decimal32(precision1), Value::Decimal32(precision2, _)) => {
                 precision1 == precision2
             }

--- a/klickhouse/src/types/mod.rs
+++ b/klickhouse/src/types/mod.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, str::FromStr};
 
 pub use chrono_tz::Tz;
 use futures_util::FutureExt;
-use half::bf16;
+
 use uuid::Uuid;
 
 mod deserialize;
@@ -161,7 +161,7 @@ impl Type {
             Type::UInt256 => Value::UInt256(u256::default()),
             Type::Float32 => Value::Float32(0.0),
             Type::Float64 => Value::Float64(0.0),
-            Type::BFloat16 => Value::BFloat16(bf16::ZERO),
+            Type::BFloat16 => crate::default_bf16_value(),
             Type::Decimal32(s) => Value::Decimal32(*s, 0),
             Type::Decimal64(s) => Value::Decimal64(*s, 0),
             Type::Decimal128(s) => Value::Decimal128(*s, 0),
@@ -469,7 +469,13 @@ impl FromStr for Type {
             "UInt256" => Type::UInt256,
             "Float32" => Type::Float32,
             "Float64" => Type::Float64,
-            "BFloat16" => Type::BFloat16,
+            "BFloat16" => {
+                if crate::is_bfloat16_enabled() {
+                    Type::BFloat16
+                } else {
+                    return Err(KlickhouseError::TypeParseError("BFloat16 type is not supported. Enable the 'bfloat16' feature to use this type.".to_string()));
+                }
+            }
             "String" => Type::String,
             "UUID" => Type::Uuid,
             "Date" => Type::Date,
@@ -977,8 +983,8 @@ impl Type {
             | (Type::UInt128, Value::UInt128(_))
             | (Type::UInt256, Value::UInt256(_))
             | (Type::Float32, Value::Float32(_))
-            | (Type::Float64, Value::Float64(_))
-            | (Type::BFloat16, Value::BFloat16(_)) => true,
+            | (Type::Float64, Value::Float64(_)) => true,
+            (Type::BFloat16, Value::BFloat16(_)) => crate::is_bfloat16_enabled(),
             (Type::Decimal32(precision1), Value::Decimal32(precision2, _)) => {
                 precision1 == precision2
             }

--- a/klickhouse/src/types/mod.rs
+++ b/klickhouse/src/types/mod.rs
@@ -3,7 +3,6 @@ use std::{fmt::Display, str::FromStr};
 
 pub use chrono_tz::Tz;
 use futures_util::FutureExt;
-
 use uuid::Uuid;
 
 mod deserialize;

--- a/klickhouse/src/types/serialize/sized.rs
+++ b/klickhouse/src/types/serialize/sized.rs
@@ -34,7 +34,11 @@ impl Serializer for SizedSerializer {
                 Value::UInt256(x) => writer.write_all(&swap_endian_256(x.0)[..]).await?,
                 Value::Float32(x) => writer.write_u32_le(x.to_bits()).await?,
                 Value::Float64(x) => writer.write_u64_le(x.to_bits()).await?,
-                Value::BFloat16(x) => writer.write_u16_le(x.to_bits()).await?,
+                Value::BFloat16(x) => {
+                    writer
+                        .write_u16_le(crate::serialize_bf16_to_bits(x))
+                        .await?
+                }
                 Value::Decimal32(_, x) => writer.write_i32_le(*x).await?,
                 Value::Decimal64(_, x) => writer.write_i64_le(*x).await?,
                 Value::Decimal128(_, x) => writer.write_i128_le(*x).await?,

--- a/klickhouse/src/types/serialize/sized.rs
+++ b/klickhouse/src/types/serialize/sized.rs
@@ -34,6 +34,7 @@ impl Serializer for SizedSerializer {
                 Value::UInt256(x) => writer.write_all(&swap_endian_256(x.0)[..]).await?,
                 Value::Float32(x) => writer.write_u32_le(x.to_bits()).await?,
                 Value::Float64(x) => writer.write_u64_le(x.to_bits()).await?,
+                Value::BFloat16(x) => writer.write_u16_le(x.to_bits()).await?,
                 Value::Decimal32(_, x) => writer.write_i32_le(*x).await?,
                 Value::Decimal64(_, x) => writer.write_i64_le(*x).await?,
                 Value::Decimal128(_, x) => writer.write_i128_le(*x).await?,

--- a/klickhouse/src/types/serialize/sized.rs
+++ b/klickhouse/src/types/serialize/sized.rs
@@ -1,6 +1,6 @@
 use tokio::io::AsyncWriteExt;
 
-use crate::{io::ClickhouseWrite, values::Value, Result};
+use crate::{io::ClickhouseWrite, serialize_bf16_to_bits, values::Value, Result};
 
 use super::{Serializer, SerializerState, Type};
 
@@ -34,11 +34,7 @@ impl Serializer for SizedSerializer {
                 Value::UInt256(x) => writer.write_all(&swap_endian_256(x.0)[..]).await?,
                 Value::Float32(x) => writer.write_u32_le(x.to_bits()).await?,
                 Value::Float64(x) => writer.write_u64_le(x.to_bits()).await?,
-                Value::BFloat16(x) => {
-                    writer
-                        .write_u16_le(crate::serialize_bf16_to_bits(x))
-                        .await?
-                }
+                Value::BFloat16(x) => writer.write_u16_le(serialize_bf16_to_bits(x)).await?,
                 Value::Decimal32(_, x) => writer.write_i32_le(*x).await?,
                 Value::Decimal64(_, x) => writer.write_i64_le(*x).await?,
                 Value::Decimal128(_, x) => writer.write_i128_le(*x).await?,

--- a/klickhouse/src/types/tests.rs
+++ b/klickhouse/src/types/tests.rs
@@ -1,6 +1,5 @@
 use std::io::Cursor;
 
-use half::bf16;
 use crate::Result;
 use crate::{
     i256,
@@ -9,6 +8,8 @@ use crate::{
     values::{self, Value},
     Date, DateTime, DynDateTime64,
 };
+#[cfg(feature = "bfloat16")]
+use half::bf16;
 use uuid::Uuid;
 
 use super::Type;
@@ -223,6 +224,7 @@ async fn roundtrip_f64() {
 }
 
 #[tokio::test]
+#[cfg(feature = "bfloat16")]
 async fn roundtrip_bf16() {
     let values = &[
         Value::BFloat16(bf16::from_f32(1.00)),
@@ -237,7 +239,9 @@ async fn roundtrip_bf16() {
     ];
     assert_eq!(
         &values[..],
-        roundtrip_values(&Type::BFloat16, &values[..]).await.unwrap()
+        roundtrip_values(&Type::BFloat16, &values[..])
+            .await
+            .unwrap()
     );
 }
 

--- a/klickhouse/src/types/tests.rs
+++ b/klickhouse/src/types/tests.rs
@@ -1,5 +1,6 @@
 use std::io::Cursor;
 
+use half::bf16;
 use crate::Result;
 use crate::{
     i256,
@@ -218,6 +219,25 @@ async fn roundtrip_f64() {
     assert_eq!(
         &values[..],
         roundtrip_values(&Type::Float64, &values[..]).await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn roundtrip_bf16() {
+    let values = &[
+        Value::BFloat16(bf16::from_f32(1.00)),
+        Value::BFloat16(bf16::from_f32(0.0)),
+        Value::BFloat16(bf16::from_f32(100.0)),
+        Value::BFloat16(bf16::from_f32(100000.0)),
+        Value::BFloat16(bf16::from_f32(1000000.0)),
+        Value::BFloat16(bf16::from_f32(-1000000.0)),
+        Value::BFloat16(bf16::NAN),
+        Value::BFloat16(bf16::INFINITY),
+        Value::BFloat16(bf16::NEG_INFINITY),
+    ];
+    assert_eq!(
+        &values[..],
+        roundtrip_values(&Type::BFloat16, &values[..]).await.unwrap()
     );
 }
 

--- a/klickhouse/src/values/bfloat16.rs
+++ b/klickhouse/src/values/bfloat16.rs
@@ -116,7 +116,7 @@ pub const fn is_bfloat16_enabled() -> bool {
 mod tests {
     #[cfg(feature = "bfloat16")]
     use crate::{FromSql, ToSql, Type};
-    
+
     use super::*;
 
     #[test]

--- a/klickhouse/src/values/bfloat16.rs
+++ b/klickhouse/src/values/bfloat16.rs
@@ -1,0 +1,184 @@
+//! BFloat16 support for ClickHouse values
+//!
+//! This module provides BFloat16 functionality when the `bfloat16` feature is enabled.
+//! When disabled, it provides stub implementations to maintain API compatibility.
+
+#[cfg(feature = "bfloat16")]
+pub use half::bf16;
+
+use crate::Value;
+
+/// Stub BFloat16 type used when the `bfloat16` feature is disabled
+#[cfg(not(feature = "bfloat16"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[allow(non_camel_case_types)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct bf16;
+
+#[cfg(not(feature = "bfloat16"))]
+impl bf16 {
+    /// Stub implementation that returns zero
+    pub fn to_bits(self) -> u16 {
+        0
+    }
+
+    /// Stub implementation that ignores input
+    pub fn from_bits(_bits: u16) -> Self {
+        bf16
+    }
+
+    /// Stub implementation that returns zero
+    pub fn to_f32(self) -> f32 {
+        0.0
+    }
+
+    /// Stub implementation that ignores input
+    pub fn from_f32(_value: f32) -> Self {
+        bf16
+    }
+
+    /// Stub constant
+    pub const ZERO: bf16 = bf16;
+    pub const ONE: bf16 = bf16;
+    pub const NAN: bf16 = bf16;
+    pub const INFINITY: bf16 = bf16;
+    pub const NEG_INFINITY: bf16 = bf16;
+
+    /// Stub implementation
+    pub fn is_nan(self) -> bool {
+        false
+    }
+}
+
+#[cfg(not(feature = "bfloat16"))]
+impl std::fmt::Display for bf16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<bfloat16 disabled>")
+    }
+}
+
+/// Creates a default BFloat16 value
+#[cfg(feature = "bfloat16")]
+pub fn default_bf16_value() -> Value {
+    Value::BFloat16(bf16::ZERO)
+}
+
+/// Error stub for default value when feature is disabled
+#[cfg(not(feature = "bfloat16"))]
+pub fn default_bf16_value() -> Value {
+    panic!("BFloat16 support is disabled. Enable the 'bfloat16' feature to use BFloat16 types.")
+}
+
+/// Deserializes BFloat16 from bits when feature is enabled
+#[cfg(feature = "bfloat16")]
+pub fn deserialize_bf16_from_bits(bits: u16) -> Value {
+    Value::BFloat16(bf16::from_bits(bits))
+}
+
+/// Error stub for deserialization when feature is disabled
+#[cfg(not(feature = "bfloat16"))]
+pub fn deserialize_bf16_from_bits(_bits: u16) -> Value {
+    panic!("BFloat16 support is disabled. Enable the 'bfloat16' feature to deserialize BFloat16 values.")
+}
+
+/// Serializes BFloat16 to bits when feature is enabled
+#[cfg(feature = "bfloat16")]
+pub fn serialize_bf16_to_bits(value: &bf16) -> u16 {
+    value.to_bits()
+}
+
+/// Error stub for serialization when feature is disabled
+#[cfg(not(feature = "bfloat16"))]
+pub fn serialize_bf16_to_bits(_value: &bf16) -> u16 {
+    panic!(
+        "BFloat16 support is disabled. Enable the 'bfloat16' feature to serialize BFloat16 values."
+    )
+}
+
+/// Hashes a BFloat16 value
+#[cfg(feature = "bfloat16")]
+pub fn hash_bf16<H: std::hash::Hasher>(value: &bf16, state: &mut H) {
+    std::hash::Hash::hash(&value.to_bits(), state);
+}
+
+/// Stub hash when feature is disabled
+#[cfg(not(feature = "bfloat16"))]
+pub fn hash_bf16<H: std::hash::Hasher>(_value: &bf16, state: &mut H) {
+    std::hash::Hash::hash(&0u16, state);
+}
+
+/// Checks if the bfloat16 feature is enabled at compile time
+pub const fn is_bfloat16_enabled() -> bool {
+    cfg!(feature = "bfloat16")
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "bfloat16")]
+    use crate::{FromSql, ToSql, Type};
+    
+    use super::*;
+
+    #[test]
+    fn test_feature_detection() {
+        assert_eq!(is_bfloat16_enabled(), cfg!(feature = "bfloat16"));
+    }
+
+    #[cfg(feature = "bfloat16")]
+    #[test]
+    fn test_bf16_functionality() {
+        let value = bf16::from_f32(42.5);
+        assert_eq!(value.to_f32(), 42.5);
+
+        let bits = value.to_bits();
+        let restored = bf16::from_bits(bits);
+        assert_eq!(restored.to_bits(), value.to_bits());
+    }
+
+    #[cfg(feature = "bfloat16")]
+    #[test]
+    fn test_bf16_to_from_sql() {
+        let value = bf16::from_f32(123.456);
+
+        // Test ToSql
+        let sql_value = value.to_sql(None).unwrap();
+        match sql_value {
+            Value::BFloat16(v) => assert_eq!(v.to_bits(), value.to_bits()),
+            _ => panic!("Expected BFloat16 value"),
+        }
+
+        // Test FromSql
+        let restored = bf16::from_sql(&Type::BFloat16, Value::BFloat16(value)).unwrap();
+        assert_eq!(restored.to_bits(), value.to_bits());
+
+        // Test special values
+        let special_values = [
+            bf16::from_f32(0.0),
+            bf16::from_f32(-0.0),
+            bf16::from_f32(1.0),
+            bf16::from_f32(-1.0),
+            bf16::INFINITY,
+            bf16::NEG_INFINITY,
+            bf16::NAN,
+        ];
+
+        for &val in &special_values {
+            let sql_val = val.to_sql(None).unwrap();
+            let restored_val = bf16::from_sql(&Type::BFloat16, sql_val).unwrap();
+            if val.is_nan() {
+                assert!(restored_val.is_nan());
+            } else {
+                assert_eq!(restored_val.to_bits(), val.to_bits());
+            }
+        }
+    }
+
+    #[cfg(not(feature = "bfloat16"))]
+    #[test]
+    fn test_bf16_stub() {
+        let value = bf16;
+        assert_eq!(value.to_bits(), 0);
+        assert_eq!(value.to_f32(), 0.0);
+        assert!(!value.is_nan());
+    }
+}

--- a/klickhouse/src/values/mod.rs
+++ b/klickhouse/src/values/mod.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, fmt, hash::Hash};
 
 use chrono::{NaiveDate, SecondsFormat};
 use chrono_tz::Tz;
+use half::bf16;
 
 use crate::{
     convert::{unexpected_type, FromSql, ToSql},
@@ -51,6 +52,7 @@ pub enum Value {
 
     Float32(f32),
     Float64(f64),
+    BFloat16(bf16),
 
     Decimal32(usize, i32),
     Decimal64(usize, i64),
@@ -269,6 +271,7 @@ impl Value {
             Value::UInt256(_) => Type::UInt256,
             Value::Float32(_) => Type::Float32,
             Value::Float64(_) => Type::Float64,
+            Value::BFloat16(_) => Type::BFloat16,
             Value::Decimal32(p, _) => Type::Decimal32(*p),
             Value::Decimal64(p, _) => Type::Decimal64(*p),
             Value::Decimal128(p, _) => Type::Decimal128(*p),
@@ -347,6 +350,7 @@ impl fmt::Display for Value {
             Value::UInt256(x) => write!(f, "{x}::UInt256"),
             Value::Float32(x) => write!(f, "{x}"),
             Value::Float64(x) => write!(f, "{x}"),
+            Value::BFloat16(x) => write!(f, "{x}"),
             Value::Decimal32(precision, value) => {
                 let raw_value = value.to_string();
                 if raw_value.len() < *precision {

--- a/klickhouse/src/values/mod.rs
+++ b/klickhouse/src/values/mod.rs
@@ -104,6 +104,7 @@ impl PartialEq for Value {
             (Self::UInt256(l0), Self::UInt256(r0)) => l0 == r0,
             (Self::Float32(l0), Self::Float32(r0)) => l0.to_bits() == r0.to_bits(),
             (Self::Float64(l0), Self::Float64(r0)) => l0.to_bits() == r0.to_bits(),
+            (Self::BFloat16(l0), Self::BFloat16(r0)) => l0.to_bits() == r0.to_bits(),
             (Self::Decimal32(l0, l1), Self::Decimal32(r0, r1)) => l0 == r0 && l1 == r1,
             (Self::Decimal64(l0, l1), Self::Decimal64(r0, r1)) => l0 == r0 && l1 == r1,
             (Self::Decimal128(l0, l1), Self::Decimal128(r0, r1)) => l0 == r0 && l1 == r1,
@@ -147,6 +148,7 @@ impl Hash for Value {
             Value::UInt256(x) => ::core::hash::Hash::hash(x, state),
             Value::Float32(x) => ::core::hash::Hash::hash(&x.to_bits(), state),
             Value::Float64(x) => ::core::hash::Hash::hash(&x.to_bits(), state),
+            Value::BFloat16(x) => ::core::hash::Hash::hash(&x.to_bits(), state),
             Value::Decimal32(x, __self_1) => {
                 ::core::hash::Hash::hash(x, state);
                 ::core::hash::Hash::hash(__self_1, state)

--- a/klickhouse/src/values/mod.rs
+++ b/klickhouse/src/values/mod.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, fmt, hash::Hash};
 
 use chrono::{NaiveDate, SecondsFormat};
 use chrono_tz::Tz;
-use half::bf16;
 
 use crate::{
     convert::{unexpected_type, FromSql, ToSql},
@@ -10,6 +9,7 @@ use crate::{
     Result,
 };
 
+mod bfloat16;
 mod bytes;
 mod clickhouse_uuid;
 mod date;
@@ -20,6 +20,7 @@ mod geo;
 mod int256;
 mod ip;
 
+pub use bfloat16::*;
 pub use bytes::*;
 pub use date::*;
 pub use fixed_point::*;
@@ -148,7 +149,7 @@ impl Hash for Value {
             Value::UInt256(x) => ::core::hash::Hash::hash(x, state),
             Value::Float32(x) => ::core::hash::Hash::hash(&x.to_bits(), state),
             Value::Float64(x) => ::core::hash::Hash::hash(&x.to_bits(), state),
-            Value::BFloat16(x) => ::core::hash::Hash::hash(&x.to_bits(), state),
+            Value::BFloat16(x) => hash_bf16(x, state),
             Value::Decimal32(x, __self_1) => {
                 ::core::hash::Hash::hash(x, state);
                 ::core::hash::Hash::hash(__self_1, state)

--- a/klickhouse/src/values/tests.rs
+++ b/klickhouse/src/values/tests.rs
@@ -1,4 +1,5 @@
 use chrono_tz::UTC;
+#[cfg(feature = "bfloat16")]
 use half::bf16;
 use indexmap::IndexMap;
 use uuid::Uuid;
@@ -147,6 +148,7 @@ fn roundtrip_f64() {
 }
 
 #[test]
+#[cfg(feature = "bfloat16")]
 fn roundtrip_bf16() {
     let floats: &[bf16] = &[
         bf16::from_f32(1.00),
@@ -161,7 +163,10 @@ fn roundtrip_bf16() {
     ];
 
     for float in floats {
-        assert_eq!(float.to_bits(), roundtrip(*float, &Type::BFloat16).to_bits());
+        assert_eq!(
+            float.to_bits(),
+            roundtrip(*float, &Type::BFloat16).to_bits()
+        );
     }
 }
 

--- a/klickhouse/src/values/tests.rs
+++ b/klickhouse/src/values/tests.rs
@@ -1,4 +1,5 @@
 use chrono_tz::UTC;
+use half::bf16;
 use indexmap::IndexMap;
 use uuid::Uuid;
 
@@ -142,6 +143,25 @@ fn roundtrip_f64() {
 
     for float in FLOATS {
         assert_eq!(float.to_bits(), roundtrip(*float, &Type::Float64).to_bits());
+    }
+}
+
+#[test]
+fn roundtrip_bf16() {
+    let floats: &[bf16] = &[
+        bf16::from_f32(1.00),
+        bf16::from_f32(0.0),
+        bf16::from_f32(100.0),
+        bf16::from_f32(100000.0),
+        bf16::from_f32(1000000.0),
+        bf16::from_f32(-1000000.0),
+        bf16::NAN,
+        bf16::INFINITY,
+        bf16::NEG_INFINITY,
+    ];
+
+    for float in floats {
+        assert_eq!(float.to_bits(), roundtrip(*float, &Type::BFloat16).to_bits());
     }
 }
 

--- a/klickhouse/tests/test.rs
+++ b/klickhouse/tests/test.rs
@@ -1,5 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+use half::bf16;
 use indexmap::IndexMap;
 use klickhouse::{
     i256, u256, Date, DateTime, DateTime64, FixedPoint128, FixedPoint256, FixedPoint32,
@@ -22,6 +23,7 @@ pub struct TestType {
     d_u256: u256,
     d_f32: f32,
     d_f64: f64,
+    d_bf16: bf16,
     d_d32: FixedPoint32<5>,
     d_d64: FixedPoint64<5>,
     d_d128: FixedPoint128<5>,
@@ -76,6 +78,7 @@ async fn test_client() {
         d_u256 UInt256 default 0,
         d_f32 Float32 default 0,
         d_f64 Float64 default 0,
+        d_bf16 BFloat16 default 0,
         d_d32 Decimal32(5) default 0,
         d_d64 Decimal64(5) default 0,
         d_d128 Decimal128(5) default 0,

--- a/klickhouse/tests/test.rs
+++ b/klickhouse/tests/test.rs
@@ -1,5 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+#[cfg(feature = "bfloat16")]
 use half::bf16;
 use indexmap::IndexMap;
 use klickhouse::{
@@ -23,6 +24,7 @@ pub struct TestType {
     d_u256: u256,
     d_f32: f32,
     d_f64: f64,
+    #[cfg(feature = "bfloat16")]
     d_bf16: bf16,
     d_d32: FixedPoint32<5>,
     d_d64: FixedPoint64<5>,
@@ -63,7 +65,13 @@ async fn test_client() {
         .try_init();
     let client = super::get_client().await;
 
-    super::prepare_table("test_types", r"
+    let bfloat16_field = if cfg!(feature = "bfloat16") {
+        "\n        d_bf16 BFloat16 default 0,"
+    } else {
+        ""
+    };
+
+    let table_sql = format!("
         d_i8 Int8 default 0,
         d_i16 Int16 default 0,
         d_i32 Int32 default 0,
@@ -77,8 +85,7 @@ async fn test_client() {
         -- d_u128 UInt128 default 0,
         d_u256 UInt256 default 0,
         d_f32 Float32 default 0,
-        d_f64 Float64 default 0,
-        d_bf16 BFloat16 default 0,
+        d_f64 Float64 default 0,{bfloat16_field}
         d_d32 Decimal32(5) default 0,
         d_d64 Decimal64(5) default 0,
         d_d128 Decimal128(5) default 0,
@@ -102,7 +109,9 @@ async fn test_client() {
         d_low_card_array_nulls Array(LowCardinality(Nullable(String))),
         d_ip4 IPv4,
         d_ip6 IPv6
-    ", &client).await;
+    ", bfloat16_field = bfloat16_field);
+
+    super::prepare_table("test_types", &table_sql, &client).await;
 
     println!("begin insert");
 


### PR DESCRIPTION
Add support for the [BFloat16](https://clickhouse.com/docs/sql-reference/data-types/float#bfloat16) data type using the bf16 type from the [half](https://crates.io/crates/half) crate.

Closes #82.