### PR TITLE
fix: wait for native insert server response

### DIFF
--- a/klickhouse/src/client.rs
+++ b/klickhouse/src/client.rs
@@ -386,7 +386,8 @@ impl Client {
     }
 
     /// Sends a query string with streaming associated data (i.e. insert) over native protocol.
-    /// Once all outgoing blocks are written (EOF of `blocks` stream), then any response blocks from Clickhouse are read and DISCARDED.
+    /// Once all outgoing blocks are written (EOF of `blocks` stream), then any response blocks
+    /// from Clickhouse are read and DISCARDED, but server-side exceptions are returned.
     /// Make sure any query you send native data with has a `format native` suffix.
     pub async fn insert_native<T: Row + Send + Sync + 'static>(
         &self,
@@ -453,6 +454,11 @@ impl Client {
             column_data: IndexMap::new(),
         })
         .await?;
+
+        while let Some(item) = receiver.recv().await {
+            item?;
+        }
+
         Ok(())
     }
 

--- a/klickhouse/tests/main.rs
+++ b/klickhouse/tests/main.rs
@@ -5,6 +5,7 @@ pub mod test_enum;
 pub mod test_flatten;
 #[cfg(feature = "geo-types")]
 pub mod test_geo;
+pub mod test_insert_native_exception;
 pub mod test_into;
 pub mod test_lock;
 pub mod test_nested;

--- a/klickhouse/tests/test_insert_native_exception.rs
+++ b/klickhouse/tests/test_insert_native_exception.rs
@@ -1,0 +1,155 @@
+use futures_util::StreamExt;
+use klickhouse::block::{Block, BlockInfo};
+use klickhouse::{Client, IndexMap, KlickhouseError, Type, UnitValue, Value};
+
+#[derive(klickhouse::Row, Debug)]
+struct ConstraintRow {
+    id: u32,
+}
+
+fn init_logger() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .try_init();
+}
+
+fn assert_server_exception(result: std::result::Result<(), KlickhouseError>, context: &str) {
+    assert!(
+        matches!(result, Err(KlickhouseError::ServerException { .. })),
+        "{context} must propagate ClickHouse errors after data blocks are sent, got {result:?}"
+    );
+}
+
+async fn prepare_constraint_table(client: &Client, table_name: &str) {
+    client
+        .execute(format!("DROP TABLE IF EXISTS {table_name}"))
+        .await
+        .unwrap();
+    client
+        .execute(format!(
+            "CREATE TABLE {table_name} (
+                id UInt32,
+                CONSTRAINT id_at_least_100 CHECK id >= 100
+            ) ENGINE = MergeTree ORDER BY id"
+        ))
+        .await
+        .unwrap();
+}
+
+/// ClickHouse rejects this row only after the native data block is received and
+/// validated server-side. A plain SQL insert confirms the server would fail.
+async fn assert_clickhouse_rejects_row(client: &Client, table_name: &str) {
+    let sql_result = client
+        .execute(format!("INSERT INTO {table_name} VALUES (1)"))
+        .await;
+    assert!(
+        sql_result.is_err(),
+        "expected ClickHouse to reject id=1 via SQL insert"
+    );
+}
+
+fn violating_row_block() -> Block {
+    let mut column_types = IndexMap::new();
+    column_types.insert("id".to_string(), Type::UInt32);
+    let mut column_data = IndexMap::new();
+    column_data.insert("id".to_string(), vec![Value::UInt32(1)]);
+
+    Block {
+        info: BlockInfo::default(),
+        rows: 1,
+        column_types,
+        column_data,
+    }
+}
+
+/// `insert_native` must not return success before observing the final server
+/// response. Otherwise post-data exceptions are dropped when the query receiver
+/// is closed.
+#[tokio::test]
+async fn insert_native_block_returns_server_error_after_data_sent() {
+    init_logger();
+    let client = super::get_client().await;
+    let table_name = "test_insert_native_exception_block";
+
+    prepare_constraint_table(&client, table_name).await;
+    assert_clickhouse_rejects_row(&client, table_name).await;
+
+    let result = client
+        .insert_native_block(
+            format!("INSERT INTO {table_name} FORMAT Native"),
+            vec![ConstraintRow { id: 1 }],
+        )
+        .await;
+
+    assert_server_exception(result, "insert_native_block");
+
+    let count = client
+        .query_one::<UnitValue<u64>>(format!("SELECT count() FROM {table_name}"))
+        .await
+        .unwrap()
+        .0;
+    assert_eq!(count, 0);
+}
+
+/// The streaming API must also wait for ClickHouse's final response after all
+/// outgoing blocks have been sent, not just the single-block wrapper path.
+#[tokio::test]
+async fn insert_native_stream_returns_server_error_after_multiple_data_blocks_sent() {
+    init_logger();
+    let client = super::get_client().await;
+    let table_name = "test_insert_native_exception_stream";
+
+    prepare_constraint_table(&client, table_name).await;
+    assert_clickhouse_rejects_row(&client, table_name).await;
+
+    let result = client
+        .insert_native(
+            format!("INSERT INTO {table_name} FORMAT Native"),
+            futures_util::stream::iter(vec![
+                vec![ConstraintRow { id: 100 }],
+                vec![ConstraintRow { id: 1 }],
+            ]),
+        )
+        .await;
+
+    assert_server_exception(result, "insert_native");
+
+    let invalid_count = client
+        .query_one::<UnitValue<u64>>(format!("SELECT count() FROM {table_name} WHERE id < 100"))
+        .await
+        .unwrap()
+        .0;
+    assert_eq!(invalid_count, 0);
+}
+
+/// The same failing insert is observable when the caller drains `insert_native_raw`.
+#[tokio::test]
+async fn insert_native_raw_observes_server_exception_when_drained() {
+    init_logger();
+    let client = super::get_client().await;
+    let table_name = "test_insert_native_exception_raw";
+
+    prepare_constraint_table(&client, table_name).await;
+    assert_clickhouse_rejects_row(&client, table_name).await;
+
+    let mut stream = client
+        .insert_native_raw(
+            format!("INSERT INTO {table_name} FORMAT Native"),
+            futures_util::stream::iter([violating_row_block()]),
+        )
+        .await
+        .unwrap();
+
+    let mut saw_server_exception = false;
+    while let Some(item) = stream.next().await {
+        if matches!(item, Err(KlickhouseError::ServerException { .. })) {
+            saw_server_exception = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_server_exception,
+        "draining insert_native_raw should observe the server exception"
+    );
+}


### PR DESCRIPTION
## Summary

- wait for ClickHouse to finish native inserts after sending the final empty data block
- propagate server-side insert exceptions instead of returning success early
- add regression coverage for constraint failures reported after Native data is sent

## Why this is needed

`Client::insert_native` currently waits for the initial server data block that describes the insert schema, streams the client data blocks, sends the final empty data block, and then returns `Ok(())` immediately.

That means the caller can observe a successful insert before the server has actually finished processing the query. If ClickHouse reports an `Exception` after receiving the data, the background connection task may try to forward that error to a query receiver that has already been dropped. The send failure is ignored, so the original caller still sees success.

This can happen for server-side validation and ingestion failures that are only known after ClickHouse reads the Native data blocks. Applications that treat `insert_native` success as durable persistence can then acknowledge or discard upstream work even though ClickHouse rejected the insert.

## Protocol behavior

The Native protocol does not provide a per-data-block success acknowledgement. Client `Data` packets stream input to the query, and the server reports query completion with `EndOfStream` or query failure with `Exception`.

For that reason this change does not wait after every data block. Instead, after the final empty data block is sent, `insert_native` drains the remaining server response and returns the first server error it receives. It only returns `Ok(())` once the response stream is exhausted after ClickHouse has completed the query.

## Testing

- `cargo test -p klickhouse --test test test_insert_native_exception --no-run`

The new regression tests create a table with a `CHECK` constraint and insert invalid Native data. The row is rejected by ClickHouse after data submission, and `insert_native_block` / `insert_native` now return the server exception to the caller.
